### PR TITLE
Fix: use username/password when doing tox publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
                         env.NEW_PACKAGE_VERSION = sh(script: "bumpversion --current-version ${CURRENT_PACKAGE_VERSION} --list ${RELEASE_SCOPE} | grep new_version= | cut -d'=' -f2", returnStdout: true).trim()
                     }
 
-                    sh "tox -e --publish -- --repository pypi"
+                    sh "tox -e --publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}"
 
                     sh "git push --tags origin master"
                     hubotSend(message: "molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} has been released! :tada: https://pypi.org/project/molgenis-py-bbmri-eric/", status:'SUCCESS')

--- a/tox.ini
+++ b/tox.ini
@@ -57,10 +57,6 @@ description =
     to be publicly accessible in PyPI, use the `-- --repository pypi` option.
 skip_install = True
 changedir = {toxinidir}
-passenv =
-    TWINE_USERNAME
-    TWINE_PASSWORD
-    TWINE_REPOSITORY
 deps = twine
 commands =
     python -m twine check dist/*


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] Updated CHANGELOG.md
