### PR TITLE
Fill hidden_network field of collection

### DIFF
--- a/src/molgenis/bbmri_eric/transformer.py
+++ b/src/molgenis/bbmri_eric/transformer.py
@@ -33,12 +33,14 @@ class Transformer:
         3. Sets the quality info field for biobanks and collections
         4. Adds PIDs to biobanks
         5. Replaces a node's EU rows with the data from node EU's staging area
+        6. Adds the hidden networks' ids to collections
         """
         self._set_national_node_code()
         self._replace_eu_rows()
         self._set_commercial_use_bool()
         self._set_quality_info()
         self._set_biobank_pids()
+        self._set_hidden_networks()
         return self.warnings
 
     def _set_commercial_use_bool(self):
@@ -127,3 +129,13 @@ class Transformer:
                     )
                     self.printer.print_warning(warning, indent=1)
                     self.warnings.append(warning)
+
+    def _set_hidden_networks(self):
+        """
+        For every collection of the Node, adds to the `hidden_network` field, the union of the networks of the
+        collection itself and the ones of its biobank
+        """
+        self.printer.print("Adding hidden networks")
+        for collection in self.node_data.collections.rows:
+            biobank = self.node_data.biobanks.rows_by_id[collection['biobank']]
+            collection['hidden_network'] = list(set(biobank['network'] + collection['network']))

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -166,3 +166,38 @@ def test_transformer_replace_eu_rows():
             "eu_bbmri_eric_persons"
         )
     ]
+
+
+def test_transformer_create_hidden_networks():
+    node_data = MagicMock()
+    node_data.collections.rows = [
+        {"biobank": "biobank1", "network": []},
+        {"biobank": "biobank2", "network": ["network1"]},
+        {"biobank": "biobank3", "network": ["network2"]},
+        {"biobank": "biobank4", "network": []},
+        {"biobank": "biobank5", "network": ["network1", "network2"]},
+        {"biobank": "biobank6", "network": []}
+    ]
+    node_data.biobanks.rows_by_id = {
+        "biobank1": {"network": ["network1", "network2"]},
+        "biobank2": {"network": []},
+        "biobank3": {"network": ["network1"]},
+        "biobank4": {"network": ["network2"]},
+        "biobank5": {"network": []},
+        "biobank6": {"network": []},
+    }
+
+    Transformer(
+        node_data=node_data,
+        quality=MagicMock(),
+        printer=Printer(),
+        existing_biobanks=MagicMock(),
+        eu_node_data=MagicMock(),
+    )._set_hidden_networks()
+
+    assert node_data.collections.rows[0]["hidden_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[1]["hidden_network"] == ["network1"]
+    assert node_data.collections.rows[2]["hidden_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[3]["hidden_network"] == ["network2"]
+    assert node_data.collections.rows[4]["hidden_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[5]["hidden_network"] == []


### PR DESCRIPTION
This PR adds a step to the Transformer to fill the `hidden_network` field of a collection, which contains the list of networks of the collection and of its biobank. 
This PR needs the BBMRI Eric model to define the `hidden_network` field for the collections entity. This field has the same definition as the `network` field

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] Updated CHANGELOG.md
