### PR TITLE
Adds step to fill `combined_network` field

### DIFF
--- a/src/molgenis/bbmri_eric/transformer.py
+++ b/src/molgenis/bbmri_eric/transformer.py
@@ -33,14 +33,14 @@ class Transformer:
         3. Sets the quality info field for biobanks and collections
         4. Adds PIDs to biobanks
         5. Replaces a node's EU rows with the data from node EU's staging area
-        6. Adds the hidden networks' ids to collections
+        6. Adds the combined networks' ids to collections
         """
         self._set_national_node_code()
         self._replace_eu_rows()
         self._set_commercial_use_bool()
         self._set_quality_info()
         self._set_biobank_pids()
-        self._set_hidden_networks()
+        self._set_combined_networks()
         return self.warnings
 
     def _set_commercial_use_bool(self):
@@ -130,12 +130,12 @@ class Transformer:
                     self.printer.print_warning(warning, indent=1)
                     self.warnings.append(warning)
 
-    def _set_hidden_networks(self):
+    def _set_combined_networks(self):
         """
-        For every collection of the Node, adds to the `hidden_network` field, the union of the networks of the
+        For every collection of the Node, adds to the `combined_network` field, the union of the networks of the
         collection itself and the ones of its biobank
         """
-        self.printer.print("Adding hidden networks")
+        self.printer.print("Adding combined networks")
         for collection in self.node_data.collections.rows:
             biobank = self.node_data.biobanks.rows_by_id[collection['biobank']]
-            collection['hidden_network'] = list(set(biobank['network'] + collection['network']))
+            collection['combined_network'] = list(set(biobank['network'] + collection['network']))

--- a/src/molgenis/bbmri_eric/transformer.py
+++ b/src/molgenis/bbmri_eric/transformer.py
@@ -132,10 +132,12 @@ class Transformer:
 
     def _set_combined_networks(self):
         """
-        For every collection of the Node, adds to the `combined_network` field, the union of the networks of the
-        collection itself and the ones of its biobank
+        For every collection of the Node, adds to the `combined_network` field, the
+        union of the networks of the collection itself and the ones of its biobank
         """
         self.printer.print("Adding combined networks")
         for collection in self.node_data.collections.rows:
-            biobank = self.node_data.biobanks.rows_by_id[collection['biobank']]
-            collection['combined_network'] = list(set(biobank['network'] + collection['network']))
+            biobank = self.node_data.biobanks.rows_by_id[collection["biobank"]]
+            collection["combined_network"] = list(
+                set(biobank["network"] + collection["network"])
+            )

--- a/src/molgenis/bbmri_eric/transformer.py
+++ b/src/molgenis/bbmri_eric/transformer.py
@@ -33,12 +33,14 @@ class Transformer:
         3. Sets the quality info field for biobanks and collections
         4. Adds PIDs to biobanks
         5. Replaces a node's EU rows with the data from node EU's staging area
+        6. Adds the hidden networks' ids to collections
         """
         self._set_national_node_code()
         self._replace_eu_rows()
         self._set_commercial_use_bool()
         self._set_quality_info()
         self._set_biobank_pids()
+        self._set_hidden_networks()
         return self.warnings
 
     def _set_commercial_use_bool(self):
@@ -127,3 +129,13 @@ class Transformer:
                     )
                     self.printer.print_warning(warning, indent=1)
                     self.warnings.append(warning)
+
+    def _set_hidden_networks(self):
+        """
+        For every collection of the Node, adds to the `hidden_network` field, the union of the networks of the
+        collection itself and the ones of its biobank
+        """
+        self.printer.print("Adding hidden networks")
+        for collection in self.node_data.collections.rows:
+            biobank = self.node_data.biobanks.rows_by_id[collection['biobank']]
+            collection['hidden_network'] = list(set(biobank['network'] + collection['network']))

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -166,3 +166,38 @@ def test_transformer_replace_eu_rows():
             "eu_bbmri_eric_persons"
         )
     ]
+
+
+def test_transformer_create_hidden_networks():
+    node_data = MagicMock()
+    node_data.collections.rows = [
+        {"biobank": "biobank1", "network": []},
+        {"biobank": "biobank2", "network": ["network1"]},
+        {"biobank": "biobank3", "network": ["network2"]},
+        {"biobank": "biobank4", "network": []},
+        {"biobank": "biobank5", "network": ["network1", "network2"]},
+        {"biobank": "biobank6", "network": []}
+    ]
+    node_data.biobanks.rows_by_id = {
+        "biobank1": {"network": ["network1", "network2"]},
+        "biobank2": {"network": []},
+        "biobank3": {"network": ["network1"]},
+        "biobank4": {"network": ["network2"]},
+        "biobank5": {"network": []},
+        "biobank6": {"network": []},
+    }
+
+    Transformer(
+        node_data=node_data,
+        quality=MagicMock(),
+        printer=Printer(),
+        existing_biobanks=MagicMock(),
+        eu_node_data=MagicMock(),
+    )._set_hidden_networks()
+
+    assert node_data.collections.rows[0]["hidden_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[1]["hidden_network"] == ["network1"]
+    assert node_data.collections.rows[2]["hidden_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[3]["hidden_network"] == ["network2"]
+    assert node_data.collections.rows[4]["hidden_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[5]["hidden_network"] == []

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -168,7 +168,7 @@ def test_transformer_replace_eu_rows():
     ]
 
 
-def test_transformer_create_hidden_networks():
+def test_transformer_create_combined_networks():
     node_data = MagicMock()
     node_data.collections.rows = [
         {"biobank": "biobank1", "network": []},
@@ -193,11 +193,11 @@ def test_transformer_create_hidden_networks():
         printer=Printer(),
         existing_biobanks=MagicMock(),
         eu_node_data=MagicMock(),
-    )._set_hidden_networks()
+    )._set_combined_networks()
 
-    assert node_data.collections.rows[0]["hidden_network"] == ["network1", "network2"]
-    assert node_data.collections.rows[1]["hidden_network"] == ["network1"]
-    assert node_data.collections.rows[2]["hidden_network"] == ["network1", "network2"]
-    assert node_data.collections.rows[3]["hidden_network"] == ["network2"]
-    assert node_data.collections.rows[4]["hidden_network"] == ["network1", "network2"]
-    assert node_data.collections.rows[5]["hidden_network"] == []
+    assert node_data.collections.rows[0]["combined_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[1]["combined_network"] == ["network1"]
+    assert node_data.collections.rows[2]["combined_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[3]["combined_network"] == ["network2"]
+    assert node_data.collections.rows[4]["combined_network"] == ["network1", "network2"]
+    assert node_data.collections.rows[5]["combined_network"] == []

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -176,7 +176,7 @@ def test_transformer_create_combined_networks():
         {"biobank": "biobank3", "network": ["network2"]},
         {"biobank": "biobank4", "network": []},
         {"biobank": "biobank5", "network": ["network1", "network2"]},
-        {"biobank": "biobank6", "network": []}
+        {"biobank": "biobank6", "network": []},
     ]
     node_data.biobanks.rows_by_id = {
         "biobank1": {"network": ["network1", "network2"]},
@@ -195,9 +195,18 @@ def test_transformer_create_combined_networks():
         eu_node_data=MagicMock(),
     )._set_combined_networks()
 
-    assert node_data.collections.rows[0]["combined_network"] == ["network1", "network2"]
-    assert node_data.collections.rows[1]["combined_network"] == ["network1"]
-    assert node_data.collections.rows[2]["combined_network"] == ["network1", "network2"]
-    assert node_data.collections.rows[3]["combined_network"] == ["network2"]
-    assert node_data.collections.rows[4]["combined_network"] == ["network1", "network2"]
-    assert node_data.collections.rows[5]["combined_network"] == []
+    assert set(node_data.collections.rows[0]["combined_network"]) == {
+        "network1",
+        "network2",
+    }
+    assert set(node_data.collections.rows[1]["combined_network"]) == {"network1"}
+    assert set(node_data.collections.rows[2]["combined_network"]) == {
+        "network1",
+        "network2",
+    }
+    assert set(node_data.collections.rows[3]["combined_network"]) == {"network2"}
+    assert set(node_data.collections.rows[4]["combined_network"]) == {
+        "network1",
+        "network2",
+    }
+    assert set(node_data.collections.rows[5]["combined_network"]) == set()


### PR DESCRIPTION
This PR adds a step to the Transformer to fill the `combined_network` field of a collection, which contains the list of networks of the collection and of its biobank. 
This PR needs the BBMRI Eric model to define the `combined_network` field for the collections entity. This field has the same definition as the `network` one.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] Updated CHANGELOG.md
