### PR TITLE
Publish all nodes at once

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.2.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -18,17 +18,17 @@ repos:
     args: ['--fix=auto']  # replace 'auto' with 'lf' to enforce Linux/Mac line endings or 'crlf' for Windows
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.7.0
+  rev: 5.10.1
   hooks:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 22.3.0
   hooks:
   - id: black
     language_version: python3
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+  rev: 3.9.2
   hooks:
   - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 
 ## Version 1.5.0
 - Adds step to fill combined_network field
-- Fix issue #61, import of NL data fails due to self-referencing columns
 
 ## Version 1.4.0
 - PIDs are prefixed with `1.` (example: `1.6ed7-328b-2793`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## Version 1.6.0 (development)
-- Improves indexing performance by publishing all nodes at once (requires MOLGENIS 10.0.4)
+- Improves indexing performance:
+  - by publishing all nodes at once
+  - by using the Import API
 
 ## Version 1.5.0
 - Adds step to fill combined_network field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 ## Version 1.6.0 (development)
+- Improves indexing performance by publishing all nodes at once (requires MOLGENIS 10.0.4)
 
 ## Version 1.5.0
 - Adds step to fill combined_network field
+- Fix issue #61, import of NL data fails due to self-referencing columns
 
 ## Version 1.4.0
 - PIDs are prefixed with `1.` (example: `1.6ed7-328b-2793`)

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,11 +25,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
+                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.12"
+            "version": "==2.0.9"
         },
         "dataclasses": {
             "hashes": [
@@ -41,16 +41,16 @@
         },
         "datetime": {
             "hashes": [
-                "sha256:074b0c63d4328f4de30662786fa436a0567145b2ab02f47be5af68f58afc03ec",
-                "sha256:4fcca115ddb466a1104df08d5c2a2f5805d14ca317800e1bfcea8f3d69f66e57"
+                "sha256:371dba07417b929a4fa685c2f7a3eaa6a62d60c02947831f97d4df9a9e70dfd0",
+                "sha256:5cef605bab8259ff61281762cdf3290e459fbf0b4719951d5fab967d5f2ea0ea"
             ],
-            "version": "==4.4"
+            "version": "==4.3"
         },
         "future": {
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.18.2"
         },
         "idna": {
@@ -66,7 +66,7 @@
                 "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e",
                 "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version >= '3.6'",
             "version": "==4.8.3"
         },
         "molgenis-py-bbmri-eric": {
@@ -79,76 +79,6 @@
                 "sha256:aa839f0cfe40b7afad071634e7cbb2f01ce4d7daca425256dc4649b0b4332d31"
             ],
             "version": "==2.3.1"
-        },
-        "numpy": {
-            "hashes": [
-                "sha256:012426a41bc9ab63bb158635aecccc7610e3eff5d31d1eb43bc099debc979d94",
-                "sha256:06fab248a088e439402141ea04f0fffb203723148f6ee791e9c75b3e9e82f080",
-                "sha256:0eef32ca3132a48e43f6a0f5a82cb508f22ce5a3d6f67a8329c81c8e226d3f6e",
-                "sha256:1ded4fce9cfaaf24e7a0ab51b7a87be9038ea1ace7f34b841fe3b6894c721d1c",
-                "sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76",
-                "sha256:2ea52bd92ab9f768cc64a4c3ef8f4b2580a17af0a5436f6126b08efbd1838371",
-                "sha256:36674959eed6957e61f11c912f71e78857a8d0604171dfd9ce9ad5cbf41c511c",
-                "sha256:384ec0463d1c2671170901994aeb6dce126de0a95ccc3976c43b0038a37329c2",
-                "sha256:39b70c19ec771805081578cc936bbe95336798b7edf4732ed102e7a43ec5c07a",
-                "sha256:400580cbd3cff6ffa6293df2278c75aef2d58d8d93d3c5614cd67981dae68ceb",
-                "sha256:43d4c81d5ffdff6bae58d66a3cd7f54a7acd9a0e7b18d97abb255defc09e3140",
-                "sha256:50a4a0ad0111cc1b71fa32dedd05fa239f7fb5a43a40663269bb5dc7877cfd28",
-                "sha256:603aa0706be710eea8884af807b1b3bc9fb2e49b9f4da439e76000f3b3c6ff0f",
-                "sha256:6149a185cece5ee78d1d196938b2a8f9d09f5a5ebfbba66969302a778d5ddd1d",
-                "sha256:759e4095edc3c1b3ac031f34d9459fa781777a93ccc633a472a5468587a190ff",
-                "sha256:7fb43004bce0ca31d8f13a6eb5e943fa73371381e53f7074ed21a4cb786c32f8",
-                "sha256:811daee36a58dc79cf3d8bdd4a490e4277d0e4b7d103a001a4e73ddb48e7e6aa",
-                "sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea",
-                "sha256:99abf4f353c3d1a0c7a5f27699482c987cf663b1eac20db59b8c7b061eabd7fc",
-                "sha256:a0d53e51a6cb6f0d9082decb7a4cb6dfb33055308c4c44f53103c073f649af73",
-                "sha256:a12ff4c8ddfee61f90a1633a4c4afd3f7bcb32b11c52026c92a12e1325922d0d",
-                "sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d",
-                "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4",
-                "sha256:a9d17f2be3b427fbb2bce61e596cf555d6f8a56c222bd2ca148baeeb5e5c783c",
-                "sha256:ab83f24d5c52d60dbc8cd0528759532736b56db58adaa7b5f1f76ad551416a1e",
-                "sha256:aeb9ed923be74e659984e321f609b9ba54a48354bfd168d21a2b072ed1e833ea",
-                "sha256:c843b3f50d1ab7361ca4f0b3639bf691569493a56808a0b0c54a051d260b7dbd",
-                "sha256:cae865b1cae1ec2663d8ea56ef6ff185bad091a5e33ebbadd98de2cfa3fa668f",
-                "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff",
-                "sha256:cf2402002d3d9f91c8b01e66fbb436a4ed01c6498fffed0e4c7566da1d40ee1e",
-                "sha256:d051ec1c64b85ecc69531e1137bb9751c6830772ee5c1c426dbcfe98ef5788d7",
-                "sha256:d6631f2e867676b13026e2846180e2c13c1e11289d67da08d71cacb2cd93d4aa",
-                "sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827",
-                "sha256:df609c82f18c5b9f6cb97271f03315ff0dbe481a2a02e56aeb1b1a985ce38e60"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.19.5"
-        },
-        "pandas": {
-            "hashes": [
-                "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b",
-                "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f",
-                "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648",
-                "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb",
-                "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98",
-                "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a",
-                "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11",
-                "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a",
-                "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e",
-                "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae",
-                "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d",
-                "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9",
-                "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b",
-                "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788",
-                "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca",
-                "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5",
-                "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a",
-                "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814",
-                "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d",
-                "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086",
-                "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a",
-                "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb",
-                "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782",
-                "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"
-            ],
-            "markers": "python_full_version >= '3.6.1'",
-            "version": "==1.1.5"
         },
         "pyhandle": {
             "hashes": [
@@ -164,14 +94,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==1.0.2"
         },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
-        },
         "pytz": {
             "hashes": [
                 "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
@@ -181,35 +103,43 @@
         },
         "requests": {
             "hashes": [
-                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.27.1"
+            "version": "==2.26.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373",
+                "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==59.6.0"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
+                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.1.1"
+            "version": "==4.0.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
-                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.8"
+            "version": "==1.26.7"
         },
         "zipp": {
             "hashes": [
@@ -280,11 +210,19 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "version": "==21.2.0"
+        },
+        "backports.entry-points-selectable": {
+            "hashes": [
+                "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b",
+                "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==1.1.1"
         },
         "coverage": {
             "extras": [
@@ -351,11 +289,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:0f12f552b42b5bf60dba233710bf71337d35494fc8bdd4fd6d9f6d082ad45e06",
-                "sha256:a4bc51381e01502a30e9f06dd4fa19a1712eab852b6fb0f84fd7cce0793d8ca3"
+                "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8",
+                "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.4.1"
+            "version": "==3.4.0"
         },
         "flake8": {
             "hashes": [
@@ -370,7 +308,7 @@
                 "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e",
                 "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version >= '3.6'",
             "version": "==4.8.3"
         },
         "importlib-resources": {
@@ -445,19 +383,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
-                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
             "index": "pypi",
-            "version": "==7.0.1"
+            "version": "==6.2.5"
         },
         "pytest-cov": {
             "hashes": [
@@ -475,12 +413,20 @@
             "index": "pypi",
             "version": "==0.19.2"
         },
+        "setuptools": {
+            "hashes": [
+                "sha256:22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373",
+                "sha256:4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==59.6.0"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "toml": {
@@ -488,7 +434,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -500,27 +446,27 @@
         },
         "tox": {
             "hashes": [
-                "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993",
-                "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"
+                "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10",
+                "sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca"
             ],
             "index": "pypi",
-            "version": "==3.24.5"
+            "version": "==3.24.4"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
-                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
+                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
+                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.1.1"
+            "version": "==4.0.1"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:01f5f80744d24a3743ce61858123488e91cb2dd1d3bdf92adaf1bba39ffdedf0",
-                "sha256:e7b34c9474e6476ee208c43a4d9ac1510b041c68347eabfe9a9ea0c86aa0a46b"
+                "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814",
+                "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.2"
+            "version": "==20.10.0"
         },
         "zipp": {
             "hashes": [

--- a/scripts/biobank_pid_assignment.py
+++ b/scripts/biobank_pid_assignment.py
@@ -63,6 +63,6 @@ for biobank in biobanks:
     print(f"Generated {pid} for {biobank['id']}")
 
 print("Uploading to directory")
-session.update_batched(table, [], biobanks)
+session.update(table, biobanks)
 
 print("All done!")

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     dataclasses
     molgenis-py-client>=2.3.1
-    pandas
     pyhandle>=1.0.4
     requests>=2.21.0
 

--- a/src/molgenis/bbmri_eric/bbmri_client.py
+++ b/src/molgenis/bbmri_eric/bbmri_client.py
@@ -8,8 +8,8 @@ import requests
 
 from molgenis.bbmri_eric import utils
 from molgenis.bbmri_eric.model import (
-    EricData,
     ExternalServerNode,
+    MixedData,
     Node,
     NodeData,
     QualityInfo,
@@ -265,7 +265,7 @@ class EricSession(ExtendedSession):
 
     def get_published_data(
         self, nodes: List[Node], attributes: AttributesRequest
-    ) -> EricData:
+    ) -> MixedData:
         """
         Gets the four tables that belong to one or more nodes from the published tables.
         Filters the rows based on the national_node field.
@@ -297,7 +297,7 @@ class EricSession(ExtendedSession):
                 ),
             )
 
-        return EricData.from_mixed_dict(source=Source.PUBLISHED, tables=tables)
+        return MixedData.from_mixed_dict(source=Source.PUBLISHED, tables=tables)
 
 
 class ExternalServerSession(ExtendedSession):

--- a/src/molgenis/bbmri_eric/bbmri_client.py
+++ b/src/molgenis/bbmri_eric/bbmri_client.py
@@ -63,8 +63,8 @@ class ExtendedSession(Session):
         add = utils.remove_one_to_manys(add, meta)
 
         # Do the adds and updates in batches
-        self.add_batched(meta.id, meta.self_references, add)
-        self.update_batched(meta.id, meta.self_references, update)
+        self.add_batched(meta.id, add)
+        self.update_batched(meta.id, update)
 
     def update(self, entity_type_id: str, entities: List[dict]):
         """Updates multiple entities."""
@@ -81,30 +81,18 @@ class ExtendedSession(Session):
 
         return response
 
-    def update_batched(
-        self, entity_type_id: str, self_references: List[str], entities: List[dict]
-    ):
+    def update_batched(self, entity_type_id: str, entities: List[dict]):
         """Updates multiple entities in batches of 1000."""
         # TODO updating things in bulk will fail if there are self-references across
         #  batches. Dependency resolving is needed.
-        #  2022-03: Partly solved by the next two lines. However this might not be
-        #  enough for more complex cases.
-        if self_references and len(entities) > 1000:
-            entities = utils.sort_self_references(entities, self_references)
         batches = list(batched(entities, 1000))
         for batch in batches:
             self.update(entity_type_id, batch)
 
-    def add_batched(
-        self, entity_type_id: str, self_references: List[str], entities: List[dict]
-    ):
+    def add_batched(self, entity_type_id: str, entities: List[dict]):
         """Adds multiple entities in batches of 1000."""
         # TODO adding things in bulk will fail if there are self-references across
         #  batches. Dependency resolving is needed.
-        #  2022-03: Partly solved by the next two lines. However this might not be
-        #  enough for more complex cases.
-        if self_references and len(entities) > 1000:
-            entities = utils.sort_self_references(entities, self_references)
         batches = list(batched(entities, 1000))
         for batch in batches:
             self.add_all(entity_type_id, batch)

--- a/src/molgenis/bbmri_eric/bbmri_client.py
+++ b/src/molgenis/bbmri_eric/bbmri_client.py
@@ -78,36 +78,6 @@ class ExtendedSession(Session):
         rows = self.get(entity_type_id, *args, **kwargs)
         return utils.to_upload_format(rows)
 
-    def upsert(self, entity_type_id: str, entities: List[dict]):
-        """
-        Upserts entities in an entity type.
-        @param entity_type_id: the id of the entity type to upsert to
-        @param entities: the entities to upsert
-        """
-        # Get the existing identifiers
-        meta = self.get_meta(entity_type_id)
-        id_attr = meta.id_attribute
-        existing_entities = self.get(meta.id, batch_size=10000, attributes=id_attr)
-        existing_ids = {entity[id_attr] for entity in existing_entities}
-
-        # Based on the existing identifiers, decide which rows should be added/updated
-        add = list()
-        update = list()
-        for entity in entities:
-            if entity[id_attr] in existing_ids:
-                update.append(entity)
-            else:
-                add.append(entity)
-
-        # Sanitize data: rows that are added should not contain one_to_manys
-        add = utils.remove_one_to_manys(add, meta)
-
-        # Do the adds and updates
-        if add:
-            self.add_all(meta.id, add)
-        if update:
-            self.update(meta.id, update)
-
     def update(self, entity_type_id: str, entities: List[dict]):
         """Updates multiple entities."""
         response = self._session.put(

--- a/src/molgenis/bbmri_eric/bbmri_client.py
+++ b/src/molgenis/bbmri_eric/bbmri_client.py
@@ -231,7 +231,7 @@ class EricSession(ExtendedSession):
             id_ = node.get_staging_id(table_type)
             meta = self.get_meta(id_)
 
-            tables[table_type] = Table.of(
+            tables[table_type.value] = Table.of(
                 table_type=table_type,
                 meta=meta,
                 rows=self.get_uploadable_data(id_, batch_size=10000),
@@ -253,7 +253,7 @@ class EricSession(ExtendedSession):
             id_ = table_type.base_id
             meta = self.get_meta(id_)
 
-            tables[table_type] = Table.of(
+            tables[table_type.value] = Table.of(
                 table_type=table_type,
                 meta=meta,
                 rows=self.get_uploadable_data(
@@ -284,9 +284,9 @@ class EricSession(ExtendedSession):
         for table_type in TableType.get_import_order():
             id_ = table_type.base_id
             meta = self.get_meta(id_)
-            attrs = attributes[table_type.name.lower()]
+            attrs = attributes[table_type.value]
 
-            tables[table_type] = Table.of(
+            tables[table_type.value] = Table.of(
                 table_type=table_type,
                 meta=meta,
                 rows=self.get_uploadable_data(
@@ -321,7 +321,7 @@ class ExternalServerSession(ExtendedSession):
             id_ = table_type.base_id
             meta = self.get_meta(id_)
 
-            tables[table_type] = Table.of(
+            tables[table_type.value] = Table.of(
                 table_type=table_type,
                 meta=meta,
                 rows=self.get_uploadable_data(id_, batch_size=10000),

--- a/src/molgenis/bbmri_eric/bbmri_client.py
+++ b/src/molgenis/bbmri_eric/bbmri_client.py
@@ -395,7 +395,7 @@ class EricSession(ExtendedSession):
 
     @staticmethod
     def _create_csv(table: Table, file_name: str):
-        with open(file_name, "w") as fp:
+        with open(file_name, "w", encoding="utf-8") as fp:
             writer = csv.DictWriter(
                 fp, fieldnames=table.meta.attributes, quoting=csv.QUOTE_ALL
             )

--- a/src/molgenis/bbmri_eric/bbmri_client.py
+++ b/src/molgenis/bbmri_eric/bbmri_client.py
@@ -140,8 +140,8 @@ class ExtendedSession(Session):
     def import_emx_file(
         self,
         file: Path,
-        action: ImportDataAction = ImportDataAction.ADD_UPDATE_EXISTING,
-        metadata_action: ImportMetadataAction = ImportMetadataAction.IGNORE,
+        action: ImportDataAction,
+        metadata_action: ImportMetadataAction,
     ):
         """
         Imports a file with the Import API.
@@ -376,7 +376,11 @@ class EricSession(ExtendedSession):
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             archive = self._create_emx_archive(data, tmpdir)
-            self.import_emx_file(archive)
+            self.import_emx_file(
+                archive,
+                action=ImportDataAction.ADD_UPDATE_EXISTING,
+                metadata_action=ImportMetadataAction.IGNORE,
+            )
 
     @classmethod
     def _create_emx_archive(cls, data: EricData, directory: str) -> Path:

--- a/src/molgenis/bbmri_eric/eric.py
+++ b/src/molgenis/bbmri_eric/eric.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 from molgenis.bbmri_eric.bbmri_client import AttributesRequest, EricSession
 from molgenis.bbmri_eric.errors import EricError, ErrorReport, requests_error_handler
 from molgenis.bbmri_eric.model import (
-    EricData,
     ExternalServerNode,
+    MixedData,
     Node,
     NodeData,
     Source,
@@ -109,7 +109,7 @@ class Eric:
         publisher = Publisher(
             self.session, self.printer, quality_info, self.pid_manager
         )
-        data_to_publish = EricData.from_empty(Source.TRANSFORMED)
+        data_to_publish = MixedData.from_empty(Source.TRANSFORMED)
 
         return PublishingState(
             existing_data=published_data,
@@ -129,7 +129,7 @@ class Eric:
         state.publisher.publish(state)
 
     @requests_error_handler
-    def _prepare_node_data(self, node: Node, state: PublishingState):
+    def _prepare_node_data(self, node: Node, state: PublishingState) -> NodeData:
         if isinstance(node, ExternalServerNode):
             self._stage_node(node)
 

--- a/src/molgenis/bbmri_eric/eric.py
+++ b/src/molgenis/bbmri_eric/eric.py
@@ -52,7 +52,7 @@ class Eric:
                 self._stage_node(node)
             except EricError as e:
                 self.printer.print_error(e)
-                report.add_error(node, e)
+                report.add_node_error(node, e)
 
         self.printer.print_summary(report)
         return report
@@ -77,7 +77,7 @@ class Eric:
                 state.data_to_publish.merge(node_data)
             except EricError as e:
                 self.printer.print_error(e)
-                state.report.add_error(node, e)
+                state.report.add_node_error(node, e)
 
         try:
             self._publish_nodes(state)
@@ -157,7 +157,7 @@ class Eric:
                 eu_node_data=state.eu_node_data,
             ).enrich()
             if warnings:
-                state.report.add_warnings(node_data.node, warnings)
+                state.report.add_node_warnings(node_data.node, warnings)
 
     def _manage_node_pids(self, node_data: NodeData, state: PublishingState):
         self.printer.print("🆔 Managing PIDs")
@@ -167,14 +167,14 @@ class Eric:
                 node_data.biobanks, state.existing_data.biobanks
             )
             if warnings:
-                state.report.add_warnings(node_data.node, warnings)
+                state.report.add_node_warnings(node_data.node, warnings)
 
     def _validate_node(self, node_data: NodeData, report: ErrorReport):
         self.printer.print(f"🔎 Validating staged data of node {node_data.node.code}")
         with self.printer.indentation():
             warnings = Validator(node_data, self.printer).validate()
             if warnings:
-                report.add_warnings(node_data.node, warnings)
+                report.add_node_warnings(node_data.node, warnings)
 
     def _get_node_data(self, node: Node) -> NodeData:
         try:

--- a/src/molgenis/bbmri_eric/eric.py
+++ b/src/molgenis/bbmri_eric/eric.py
@@ -115,10 +115,10 @@ class Eric:
                 state.report.add_node_error(node, e)
 
     def _publish_nodes(self, state: PublishingState):
+        self.printer.print_header(
+            f"🎁 Publishing node{'s' if len(state.nodes) > 1 else ''}"
+        )
         try:
-            self.printer.print_header(
-                f"🎁 Publishing node{'s' if len(state.nodes) > 1 else ''}"
-            )
             Publisher(
                 self.session, self.printer, state.quality_info, self.pid_manager
             ).publish(state)

--- a/src/molgenis/bbmri_eric/eric.py
+++ b/src/molgenis/bbmri_eric/eric.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from molgenis.bbmri_eric.bbmri_client import EricSession
+from molgenis.bbmri_eric.bbmri_client import AttributesRequest, EricSession
 from molgenis.bbmri_eric.errors import EricError, ErrorReport, requests_error_handler
 from molgenis.bbmri_eric.model import (
     EricData,
@@ -91,7 +91,15 @@ class Eric:
     def _prepare_state(self, nodes: List[Node]) -> PublishingState:
         self.printer.print_header("⚙️ Preparation")
         self.printer.print("📦 Retrieving existing published data")
-        published_data = self.session.get_published_data(nodes)
+        published_data = self.session.get_published_data(
+            nodes,
+            AttributesRequest(
+                persons=["id", "national_node"],
+                networks=["id", "national_node"],
+                biobanks=["id", "pid", "name", "national_node"],
+                collections=["id", "national_node"],
+            ),
+        )
         self.printer.print("📦 Retrieving quality information")
         quality_info = self.session.get_quality_info()
         self.printer.print("📦 Retrieving data of node EU")

--- a/src/molgenis/bbmri_eric/eric.py
+++ b/src/molgenis/bbmri_eric/eric.py
@@ -1,14 +1,36 @@
 from typing import List, Optional
 
+from attr import dataclass
+
 from molgenis.bbmri_eric.bbmri_client import EricSession
 from molgenis.bbmri_eric.errors import EricError, ErrorReport, requests_error_handler
-from molgenis.bbmri_eric.model import ExternalServerNode, Node, NodeData
+from molgenis.bbmri_eric.model import (
+    EricData,
+    ExternalServerNode,
+    Node,
+    NodeData,
+    QualityInfo,
+    Source,
+)
+from molgenis.bbmri_eric.pid_manager import PidManagerFactory
 from molgenis.bbmri_eric.pid_service import BasePidService
 from molgenis.bbmri_eric.printer import Printer
 from molgenis.bbmri_eric.publisher import Publisher
 from molgenis.bbmri_eric.stager import Stager
+from molgenis.bbmri_eric.transformer import Transformer
 from molgenis.bbmri_eric.validation import Validator
 from molgenis.client import MolgenisRequestError
+
+
+@dataclass
+class PublishingState:
+    existing_data: EricData
+    eu_node_data: NodeData
+    quality_info: QualityInfo
+    report: ErrorReport
+    publisher: Publisher
+    nodes: List[Node]
+    data_to_publish: EricData
 
 
 class Eric:
@@ -20,11 +42,15 @@ class Eric:
         self, session: EricSession, pid_service: Optional[BasePidService] = None
     ):
         """
-        :param BbmriSession session: an authenticated session with an ERIC directory
+        :param session: an authenticated session with an ERIC directory
+        :param pid_service: a configured PidService, required for publishing. When no
+        PidService is provided, nodes can only be staged.
         """
         self.session = session
         self.printer = Printer()
         self.pid_service: Optional[BasePidService] = pid_service
+        if pid_service:
+            self.pid_manager = PidManagerFactory.create(self.pid_service, self.printer)
 
     def stage_external_nodes(self, nodes: List[ExternalServerNode]) -> ErrorReport:
         """
@@ -56,33 +82,64 @@ class Eric:
         if not self.pid_service:
             raise ValueError("A PID service is required to publish nodes")
 
-        report = ErrorReport(nodes)
-        publisher = Publisher(self.session, self.printer, self.pid_service)
+        self.printer.print("📦 Retrieving existing published data")
+        state = self._prepare_state(nodes)
+
         for node in nodes:
             self.printer.print_node_title(node)
             try:
-                self._publish_node(node, report, publisher)
+                node_data = self._prepare_node_data(node, state)
+                state.data_to_publish.merge(node_data)
             except EricError as e:
                 self.printer.print_error(e)
-                report.add_error(node, e)
+                state.report.add_error(node, e)
 
-        self.printer.print_summary(report)
-        return report
+        try:
+            self._publish_nodes(state)
+        except EricError as e:
+            state.report.set_publishing_error(e)
+
+        self.printer.print_summary(state.report)
+        return state.report
+
+    def _prepare_state(self, nodes: List[Node]) -> PublishingState:
+        published_data = self.session.get_published_data(nodes)
+        quality_info = self.session.get_quality_info()
+        eu_node_data = self.session.get_staging_node_data(self.session.get_node("EU"))
+        report = ErrorReport(nodes)
+        publisher = Publisher(
+            self.session, self.printer, quality_info, self.pid_manager
+        )
+        data_to_publish = EricData.from_empty(Source.NONE)
+
+        return PublishingState(
+            existing_data=published_data,
+            quality_info=quality_info,
+            eu_node_data=eu_node_data,
+            report=report,
+            publisher=publisher,
+            nodes=nodes,
+            data_to_publish=data_to_publish,
+        )
+
+    def _publish_nodes(self, state: PublishingState):
+        codes = [node.code for node in state.nodes]
+        self.printer.print_header(f"📤 Publishing nodes {','.join(codes)}")
+        with self.printer.indentation():
+            warnings = state.publisher.publish(state)
+            state.report.add_publishing_warnings(warnings)
 
     @requests_error_handler
-    def _publish_node(self, node: Node, report: ErrorReport, publisher: Publisher):
-        # Stage the data if this node has an external server
+    def _prepare_node_data(self, node: Node, state: PublishingState):
         if isinstance(node, ExternalServerNode):
             self._stage_node(node)
 
-        # Get the data from the staging area
         node_data = self._get_node_data(node)
+        self._validate_node(node_data, state.report)
+        self._transform_node(node_data, state)
+        self._manage_node_pids(node_data, state)
 
-        # Validate all the rows in the staging area
-        self._validate_node(node_data, report)
-
-        # Copy the data from staging to the combined tables
-        self._publish_node_data(node_data, publisher, report)
+        return node_data
 
     @requests_error_handler
     def _stage_node(self, node: ExternalServerNode):
@@ -90,13 +147,28 @@ class Eric:
         with self.printer.indentation():
             Stager(self.session, self.printer).stage(node)
 
-    def _publish_node_data(
-        self, node_data: NodeData, publisher: Publisher, report: ErrorReport
-    ):
-        self.printer.print_sub_header(f"📤 Publishing node {node_data.node.code}")
+    def _transform_node(self, node_data: NodeData, state: PublishingState):
+        self.printer.print("✏️ Preparing data")
         with self.printer.indentation():
-            warnings = publisher.publish(node_data)
-            report.add_warnings(node_data.node, warnings)
+            warnings = Transformer(
+                node_data=node_data,
+                quality=state.quality_info,
+                printer=self.printer,
+                existing_biobanks=state.existing_data.biobanks,
+                eu_node_data=state.eu_node_data,
+            ).enrich()
+            if warnings:
+                state.report.add_warnings(node_data.node, warnings)
+
+    def _manage_node_pids(self, node_data: NodeData, state: PublishingState):
+        self.printer.print("🆔 Managing PIDs")
+        with self.printer.indentation():
+            warnings = self.pid_manager.assign_biobank_pids(node_data.biobanks)
+            self.pid_manager.update_biobank_pids(
+                node_data.biobanks, state.existing_data.biobanks
+            )
+            if warnings:
+                state.report.add_warnings(node_data.node, warnings)
 
     def _validate_node(self, node_data: NodeData, report: ErrorReport):
         self.printer.print_sub_header(

--- a/src/molgenis/bbmri_eric/eric.py
+++ b/src/molgenis/bbmri_eric/eric.py
@@ -153,7 +153,7 @@ class Eric:
                 printer=self.printer,
                 existing_biobanks=state.existing_data.biobanks,
                 eu_node_data=state.eu_node_data,
-            ).enrich()
+            ).transform()
             if warnings:
                 state.report.add_node_warnings(node_data.node, warnings)
 

--- a/src/molgenis/bbmri_eric/errors.py
+++ b/src/molgenis/bbmri_eric/errors.py
@@ -31,35 +31,33 @@ class ErrorReport:
     Summary object. Stores errors and warnings that occurred for each node.
     """
 
-    # TODO variable + method naming
-
     nodes: List[Node]
-    errors: DefaultDict[Node, EricError] = field(
+    node_errors: DefaultDict[Node, EricError] = field(
         default_factory=lambda: defaultdict(list)
     )
-    warnings: DefaultDict[Node, List[EricWarning]] = field(
+    node_warnings: DefaultDict[Node, List[EricWarning]] = field(
         default_factory=lambda: defaultdict(list)
     )
-    publishing_error: Optional[EricError] = None
+    error: Optional[EricError] = None
 
     def get_node(self, code: str) -> Optional[Node]:
         return next((node for node in self.nodes if node.code == code), None)
 
-    def add_error(self, node: Node, error: EricError):
-        self.errors[node] = error
+    def add_node_error(self, node: Node, error: EricError):
+        self.node_errors[node] = error
 
-    def add_warnings(self, node: Node, warnings: List[EricWarning]):
+    def add_node_warnings(self, node: Node, warnings: List[EricWarning]):
         if warnings:
-            self.warnings[node].extend(warnings)
+            self.node_warnings[node].extend(warnings)
 
     def set_publishing_error(self, error: EricError):
-        self.publishing_error = error
+        self.error = error
 
     def has_errors(self) -> bool:
-        return len(self.errors) > 0 or self.publishing_error
+        return len(self.node_errors) > 0 or self.error
 
     def has_warnings(self) -> bool:
-        return len(self.warnings) > 0
+        return len(self.node_warnings) > 0
 
 
 def requests_error_handler(func):

--- a/src/molgenis/bbmri_eric/errors.py
+++ b/src/molgenis/bbmri_eric/errors.py
@@ -32,10 +32,10 @@ class ErrorReport:
     """
 
     nodes: List[Node]
-    node_errors: DefaultDict[Node, EricError] = field(
+    node_errors: DefaultDict[str, EricError] = field(
         default_factory=lambda: defaultdict(list)
     )
-    node_warnings: DefaultDict[Node, List[EricWarning]] = field(
+    node_warnings: DefaultDict[str, List[EricWarning]] = field(
         default_factory=lambda: defaultdict(list)
     )
     error: Optional[EricError] = None
@@ -44,11 +44,11 @@ class ErrorReport:
         return next((node for node in self.nodes if node.code == code), None)
 
     def add_node_error(self, node: Node, error: EricError):
-        self.node_errors[node] = error
+        self.node_errors[node.code] = error
 
     def add_node_warnings(self, node: Node, warnings: List[EricWarning]):
         if warnings:
-            self.node_warnings[node].extend(warnings)
+            self.node_warnings[node.code].extend(warnings)
 
     def set_publishing_error(self, error: EricError):
         self.error = error

--- a/src/molgenis/bbmri_eric/errors.py
+++ b/src/molgenis/bbmri_eric/errors.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import DefaultDict, List
+from typing import DefaultDict, List, Optional
 
 import requests
 
@@ -39,12 +39,25 @@ class ErrorReport:
         default_factory=lambda: defaultdict(list)
     )
 
+    publishing_error: Optional[EricError] = None
+    publishing_warnings: List[EricWarning] = field(default_factory=list())
+
+    def get_node(self, code: str) -> Optional[Node]:
+        return next((node for node in self.nodes if node.code == code), None)
+
     def add_error(self, node: Node, error: EricError):
         self.errors[node] = error
 
     def add_warnings(self, node: Node, warnings: List[EricWarning]):
         if warnings:
             self.warnings[node].extend(warnings)
+
+    def add_publishing_warnings(self, warnings: List[EricWarning]):
+        if warnings:
+            self.publishing_warnings.extend(warnings)
+
+    def set_publishing_error(self, error: EricError):
+        self.publishing_error = error
 
     def has_errors(self) -> bool:
         return len(self.errors) > 0

--- a/src/molgenis/bbmri_eric/errors.py
+++ b/src/molgenis/bbmri_eric/errors.py
@@ -31,6 +31,8 @@ class ErrorReport:
     Summary object. Stores errors and warnings that occurred for each node.
     """
 
+    # TODO variable + method naming
+
     nodes: List[Node]
     errors: DefaultDict[Node, EricError] = field(
         default_factory=lambda: defaultdict(list)
@@ -38,9 +40,7 @@ class ErrorReport:
     warnings: DefaultDict[Node, List[EricWarning]] = field(
         default_factory=lambda: defaultdict(list)
     )
-
     publishing_error: Optional[EricError] = None
-    publishing_warnings: List[EricWarning] = field(default_factory=list())
 
     def get_node(self, code: str) -> Optional[Node]:
         return next((node for node in self.nodes if node.code == code), None)
@@ -52,15 +52,11 @@ class ErrorReport:
         if warnings:
             self.warnings[node].extend(warnings)
 
-    def add_publishing_warnings(self, warnings: List[EricWarning]):
-        if warnings:
-            self.publishing_warnings.extend(warnings)
-
     def set_publishing_error(self, error: EricError):
         self.publishing_error = error
 
     def has_errors(self) -> bool:
-        return len(self.errors) > 0
+        return len(self.errors) > 0 or self.publishing_error
 
     def has_warnings(self) -> bool:
         return len(self.warnings) > 0

--- a/src/molgenis/bbmri_eric/errors.py
+++ b/src/molgenis/bbmri_eric/errors.py
@@ -29,27 +29,24 @@ class EricError(Exception):
 @dataclass
 class ErrorReport:
     """
-    Summary object. Stores errors and warnings that occur during publishing.
+    Summary object. Stores errors and warnings that occur during staging or publishing.
     """
 
     nodes: List[Node]
-    node_errors: DefaultDict[str, EricError] = field(
+    node_errors: DefaultDict[Node, EricError] = field(
         default_factory=lambda: defaultdict(list)
     )
-    node_warnings: DefaultDict[str, List[EricWarning]] = field(
+    node_warnings: DefaultDict[Node, List[EricWarning]] = field(
         default_factory=lambda: defaultdict(list)
     )
     error: Optional[EricError] = None
 
-    def get_node(self, code: str) -> Optional[Node]:
-        return next((node for node in self.nodes if node.code == code), None)
-
     def add_node_error(self, node: Node, error: EricError):
-        self.node_errors[node.code] = error
+        self.node_errors[node] = error
 
     def add_node_warnings(self, node: Node, warnings: List[EricWarning]):
         if warnings:
-            self.node_warnings[node.code].extend(warnings)
+            self.node_warnings[node].extend(warnings)
 
     def set_global_error(self, error: EricError):
         self.error = error

--- a/src/molgenis/bbmri_eric/errors.py
+++ b/src/molgenis/bbmri_eric/errors.py
@@ -5,6 +5,7 @@ from typing import DefaultDict, List, Optional
 import requests
 
 from molgenis.bbmri_eric.model import Node
+from molgenis.client import MolgenisRequestError
 
 
 @dataclass(frozen=True)
@@ -28,7 +29,7 @@ class EricError(Exception):
 @dataclass
 class ErrorReport:
     """
-    Summary object. Stores errors and warnings that occurred for each node.
+    Summary object. Stores errors and warnings that occur during publishing.
     """
 
     nodes: List[Node]
@@ -50,7 +51,7 @@ class ErrorReport:
         if warnings:
             self.node_warnings[node.code].extend(warnings)
 
-    def set_publishing_error(self, error: EricError):
+    def set_global_error(self, error: EricError):
         self.error = error
 
     def has_errors(self) -> bool:
@@ -68,7 +69,7 @@ def requests_error_handler(func):
     def inner_function(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except requests.exceptions.RequestException as e:
+        except (requests.exceptions.RequestException, MolgenisRequestError) as e:
             raise EricError("Request failed") from e
 
     return inner_function

--- a/src/molgenis/bbmri_eric/model.py
+++ b/src/molgenis/bbmri_eric/model.py
@@ -1,6 +1,7 @@
 import typing
 from abc import ABC
 from collections import OrderedDict
+from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional
@@ -205,14 +206,13 @@ class NodeData(EricData):
         The metadata of an external node is the same as the metadata of its staging
         area. This method copies an external server's NodeData and changes only the
         table identifiers to point to the staging area's identifiers.
-        :return:
         """
         if self.source != Source.EXTERNAL_SERVER:
             raise ValueError("data isn't from an external server")
 
         tables = dict()
         for table in self.import_order:
-            metadata = table.meta.meta
+            metadata = deepcopy(table.meta.meta)
             metadata["data"]["id"] = self.node.get_staging_id(table.type)
             tables[table.type.value] = Table(
                 table.type, table.rows_by_id, TableMeta(metadata)

--- a/src/molgenis/bbmri_eric/model.py
+++ b/src/molgenis/bbmri_eric/model.py
@@ -46,15 +46,6 @@ class TableMeta:
                 one_to_manys.append(attribute["data"]["name"])
         return one_to_manys
 
-    @property
-    def self_references(self) -> List[str]:
-        self_references = []
-        for attribute in self.meta["data"]["attributes"]["items"]:
-            if attribute["data"]["type"] in ("xref", "mref"):
-                if self.id in attribute["data"]["refEntityType"]["self"]:
-                    self_references.append(attribute["data"]["name"])
-        return self_references
-
 
 @dataclass(frozen=True)
 class Table:

--- a/src/molgenis/bbmri_eric/model.py
+++ b/src/molgenis/bbmri_eric/model.py
@@ -207,6 +207,13 @@ class MixedData(EricData):
         self.biobanks.rows_by_id.update(other_data.biobanks.rows_by_id)
         self.collections.rows_by_id.update(other_data.collections.rows_by_id)
 
+    def remove_node_rows(self, node: Node):
+        for table in self.import_order:
+            ids_to_remove = [
+                row["id"] for row in table.rows if row["national_node"] == node.code
+            ]
+            all(table.rows_by_id.pop(id_) for id_ in ids_to_remove)
+
 
 @dataclass(frozen=True)
 class QualityInfo:

--- a/src/molgenis/bbmri_eric/model.py
+++ b/src/molgenis/bbmri_eric/model.py
@@ -132,6 +132,18 @@ class Node:
         classifier = cls._classifiers[table_type]
         return f"bbmri-eric:{classifier}:EU_"
 
+    @staticmethod
+    def of(code: str):
+        return Node(code, None)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Node):
+            return self.code == other.code
+        return False
+
+    def __hash__(self):
+        return hash(self.code)
+
 
 @dataclass(frozen=True)
 class ExternalServerNode(Node):

--- a/src/molgenis/bbmri_eric/model.py
+++ b/src/molgenis/bbmri_eric/model.py
@@ -174,28 +174,17 @@ class EricData:
         return [self.persons, self.networks, self.biobanks, self.collections]
 
     @staticmethod
-    def from_mixed_dict(source: Source, tables: Dict[TableType, Table]) -> "EricData":
-        # TODO pass separate tables instead of dict?
-        return EricData(
-            source=source,
-            persons=tables[TableType.PERSONS],
-            networks=tables[TableType.NETWORKS],
-            biobanks=tables[TableType.BIOBANKS],
-            collections=tables[TableType.COLLECTIONS],
-        )
+    def from_mixed_dict(source: Source, tables: Dict[str, Table]) -> "EricData":
+        return EricData(source=source, **tables)
 
     @staticmethod
     def from_empty(source: Source) -> "EricData":
-        all_persons = Table.of_empty(TableType.PERSONS)
-        all_networks = Table.of_empty(TableType.NETWORKS)
-        all_biobanks = Table.of_empty(TableType.BIOBANKS)
-        all_collections = Table.of_empty(TableType.COLLECTIONS)
         return EricData(
             source=source,
-            persons=all_persons,
-            networks=all_networks,
-            biobanks=all_biobanks,
-            collections=all_collections,
+            persons=Table.of_empty(TableType.PERSONS),
+            networks=Table.of_empty(TableType.NETWORKS),
+            biobanks=Table.of_empty(TableType.BIOBANKS),
+            collections=Table.of_empty(TableType.COLLECTIONS),
         )
 
     def merge(self, other_data: "EricData"):
@@ -212,17 +201,8 @@ class NodeData(EricData):
     node: Node
 
     @staticmethod
-    def from_dict(
-        node: Node, source: Source, tables: Dict[TableType, Table]
-    ) -> "NodeData":
-        return NodeData(
-            node=node,
-            source=source,
-            persons=tables[TableType.PERSONS],
-            networks=tables[TableType.NETWORKS],
-            biobanks=tables[TableType.BIOBANKS],
-            collections=tables[TableType.COLLECTIONS],
-        )
+    def from_dict(node: Node, source: Source, tables: Dict[str, Table]) -> "NodeData":
+        return NodeData(node=node, source=source, **tables)
 
 
 @dataclass(frozen=True)

--- a/src/molgenis/bbmri_eric/printer.py
+++ b/src/molgenis/bbmri_eric/printer.py
@@ -42,10 +42,6 @@ class Printer:
         self.print(title)
         self.print(border)
 
-    def print_sub_header(self, text: str):
-        self.print()
-        self.print(text)
-
     def print_error(self, error: EricError):
         message = str(error)
         if error.__cause__:

--- a/src/molgenis/bbmri_eric/printer.py
+++ b/src/molgenis/bbmri_eric/printer.py
@@ -31,7 +31,10 @@ class Printer:
         self.indents -= indent
 
     def print_node_title(self, node: Node):
-        title = f"🌍 Node {node.code} ({node.description})"
+        self.print_header(f"🌍 Node {node.code} ({node.description})")
+
+    def print_header(self, text: str):
+        title = f"{text}"
         border = "=" * (len(title) + 1)
         self.reset_indent()
         self.print()
@@ -60,7 +63,7 @@ class Printer:
         self.print("==========")
 
         for node in report.nodes:
-            if node in report.errors:
+            if node in report.errors or report.publishing_error:
                 message = f"❌ Node {node.code} failed"
                 if node in report.warnings:
                     message += f" with {len(report.warnings[node])} warning(s)"

--- a/src/molgenis/bbmri_eric/printer.py
+++ b/src/molgenis/bbmri_eric/printer.py
@@ -59,14 +59,14 @@ class Printer:
         self.print("==========")
 
         for node in report.nodes:
-            if node in report.errors or report.publishing_error:
+            if node in report.node_errors or report.error:
                 message = f"❌ Node {node.code} failed"
-                if node in report.warnings:
-                    message += f" with {len(report.warnings[node])} warning(s)"
-            elif node in report.warnings:
+                if node in report.node_warnings:
+                    message += f" with {len(report.node_warnings[node])} warning(s)"
+            elif node in report.node_warnings:
                 message = (
                     f"⚠️ Node {node.code} finished successfully with "
-                    f"{len(report.warnings[node])} warning(s)"
+                    f"{len(report.node_warnings[node])} warning(s)"
                 )
             else:
                 message = f"✅ Node {node.code} finished successfully"

--- a/src/molgenis/bbmri_eric/printer.py
+++ b/src/molgenis/bbmri_eric/printer.py
@@ -58,18 +58,15 @@ class Printer:
         self.print("📋 Summary")
         self.print("==========")
 
-        # TODO make more clear when to use node vs node.code
         for node in report.nodes:
-            if node.code in report.node_errors or report.error:
+            if node in report.node_errors or report.error:
                 message = f"❌ Node {node.code} failed"
-                if node.code in report.node_warnings:
-                    message += (
-                        f" with {len(report.node_warnings[node.code])} warning(s)"
-                    )
-            elif node.code in report.node_warnings:
+                if node in report.node_warnings:
+                    message += f" with {len(report.node_warnings[node])} warning(s)"
+            elif node in report.node_warnings:
                 message = (
                     f"⚠️ Node {node.code} finished successfully with "
-                    f"{len(report.node_warnings[node.code])} warning(s)"
+                    f"{len(report.node_warnings[node])} warning(s)"
                 )
             else:
                 message = f"✅ Node {node.code} finished successfully"

--- a/src/molgenis/bbmri_eric/printer.py
+++ b/src/molgenis/bbmri_eric/printer.py
@@ -58,15 +58,18 @@ class Printer:
         self.print("📋 Summary")
         self.print("==========")
 
+        # TODO make more clear when to use node vs node.code
         for node in report.nodes:
-            if node in report.node_errors or report.error:
+            if node.code in report.node_errors or report.error:
                 message = f"❌ Node {node.code} failed"
-                if node in report.node_warnings:
-                    message += f" with {len(report.node_warnings[node])} warning(s)"
-            elif node in report.node_warnings:
+                if node.code in report.node_warnings:
+                    message += (
+                        f" with {len(report.node_warnings[node.code])} warning(s)"
+                    )
+            elif node.code in report.node_warnings:
                 message = (
                     f"⚠️ Node {node.code} finished successfully with "
-                    f"{len(report.node_warnings[node])} warning(s)"
+                    f"{len(report.node_warnings[node.code])} warning(s)"
                 )
             else:
                 message = f"✅ Node {node.code} finished successfully"

--- a/src/molgenis/bbmri_eric/publication_preparer.py
+++ b/src/molgenis/bbmri_eric/publication_preparer.py
@@ -1,0 +1,61 @@
+from molgenis.bbmri_eric.bbmri_client import EricSession
+from molgenis.bbmri_eric.errors import ErrorReport, requests_error_handler
+from molgenis.bbmri_eric.model import Node, NodeData
+from molgenis.bbmri_eric.pid_manager import BasePidManager
+from molgenis.bbmri_eric.printer import Printer
+from molgenis.bbmri_eric.publisher import PublishingState
+from molgenis.bbmri_eric.transformer import Transformer
+from molgenis.bbmri_eric.validation import Validator
+
+
+class PublicationPreparer:
+    """Prepares nodes for publishing."""
+
+    def __init__(
+        self, printer: Printer, pid_manager: BasePidManager, session: EricSession
+    ):
+        self.printer = printer
+        self.pid_manager = pid_manager
+        self.session = session
+
+    @requests_error_handler
+    def prepare(self, node: Node, state: PublishingState) -> NodeData:
+        node_data = self._get_node_data(node)
+        self._validate_node(node_data, state.report)
+        self._transform_node(node_data, state)
+        self._manage_node_pids(node_data, state)
+        return node_data
+
+    def _validate_node(self, node_data: NodeData, report: ErrorReport):
+        self.printer.print(f"🔎 Validating staged data of node {node_data.node.code}")
+        with self.printer.indentation():
+            warnings = Validator(node_data, self.printer).validate()
+            if warnings:
+                report.add_node_warnings(node_data.node, warnings)
+
+    def _transform_node(self, node_data: NodeData, state: PublishingState):
+        self.printer.print("✏️ Preparing staged data for publishing")
+        with self.printer.indentation():
+            warnings = Transformer(
+                node_data=node_data,
+                quality=state.quality_info,
+                printer=self.printer,
+                existing_biobanks=state.existing_data.biobanks,
+                eu_node_data=state.eu_node_data,
+            ).transform()
+            if warnings:
+                state.report.add_node_warnings(node_data.node, warnings)
+
+    def _manage_node_pids(self, node_data: NodeData, state: PublishingState):
+        self.printer.print("🆔 Managing PIDs")
+        with self.printer.indentation():
+            warnings = self.pid_manager.assign_biobank_pids(node_data.biobanks)
+            self.pid_manager.update_biobank_pids(
+                node_data.biobanks, state.existing_data.biobanks
+            )
+            if warnings:
+                state.report.add_node_warnings(node_data.node, warnings)
+
+    def _get_node_data(self, node: Node) -> NodeData:
+        self.printer.print(f"📦 Retrieving staged data of node {node.code}")
+        return self.session.get_staging_node_data(node)

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -1,12 +1,9 @@
-from typing import List
-
 from molgenis.bbmri_eric.bbmri_client import EricSession
-from molgenis.bbmri_eric.errors import EricError, EricWarning
-from molgenis.bbmri_eric.model import NodeData, QualityInfo, Table, TableType
-from molgenis.bbmri_eric.pid_manager import PidManagerFactory
-from molgenis.bbmri_eric.pid_service import BasePidService
+from molgenis.bbmri_eric.eric import PublishingState
+from molgenis.bbmri_eric.errors import EricError, EricWarning, ErrorReport
+from molgenis.bbmri_eric.model import QualityInfo, Table, TableType
+from molgenis.bbmri_eric.pid_manager import BasePidManager
 from molgenis.bbmri_eric.printer import Printer
-from molgenis.bbmri_eric.transformer import Transformer
 from molgenis.client import MolgenisRequestError
 
 
@@ -17,83 +14,59 @@ class Publisher:
     """
 
     def __init__(
-        self, session: EricSession, printer: Printer, pid_service: BasePidService
+        self,
+        session: EricSession,
+        printer: Printer,
+        quality_info: QualityInfo,
+        pid_manager: BasePidManager,
     ):
         self.session = session
         self.printer = printer
-        self.pid_service = pid_service
-        self.pid_manager = PidManagerFactory.create(pid_service, printer)
-        self.warnings: List[EricWarning] = []
-        self.quality_info: QualityInfo = session.get_quality_info()
-        self.eu_node_data: NodeData = session.get_staging_node_data(
-            session.get_node("EU")
-        )
+        self.quality_info = quality_info
+        self.pid_manager = pid_manager
 
-    def publish(self, node_data: NodeData) -> List[EricWarning]:
+    def publish(self, state: PublishingState):
         """
         Publishes data from the provided node to the production tables. Before being
         copied over, the data is enriched with additional information.
         """
-        self.warnings = []
-        node = node_data.node
-
-        self.printer.print(f"📦 Retrieving existing published data of node {node.code}")
-        existing_node_data = self.session.get_published_node_data(node)
-
-        self.printer.print("✏️ Preparing data")
-        with self.printer.indentation():
-            self.warnings += Transformer(
-                node_data=node_data,
-                quality=self.quality_info,
-                printer=self.printer,
-                existing_biobanks=existing_node_data.biobanks,
-                eu_node_data=self.eu_node_data,
-            ).enrich()
-
-        self.printer.print("🆔 Managing PIDs")
-        with self.printer.indentation():
-            self.warnings += self.pid_manager.assign_biobank_pids(node_data.biobanks)
-            self.pid_manager.update_biobank_pids(
-                node_data.biobanks, existing_node_data.biobanks
-            )
-
         self.printer.print("💾 Copying data to combined tables")
         with self.printer.indentation():
-            self._copy_node_data(node_data, existing_node_data)
-        return self.warnings
+            self._publish_data(state)
 
-    def _copy_node_data(self, node_data: NodeData, existing_node_data: NodeData):
+    def _publish_data(self, state: PublishingState):
         """
-        Copies the data of a staging area to the combined tables. This happens in two
-        phases:
+        Copies staging data to the combined tables. This happens in two phases:
         1. New/existing rows are upserted in the combined tables
         2. Removed rows are deleted from the combined tables
         """
-        for table in node_data.import_order:
+        for table in state.data_to_publish.import_order:
             self.printer.print(f"Upserting rows in {table.type.base_id}")
             try:
                 self.session.upsert_batched(table.type.base_id, table.rows)
             except MolgenisRequestError as e:
                 raise EricError(f"Error upserting rows to {table.type.base_id}") from e
 
-        for table in reversed(node_data.import_order):
+        for table in reversed(state.data_to_publish.import_order):
             self.printer.print(f"Deleting rows in {table.type.base_id}")
             try:
                 with self.printer.indentation():
                     self._delete_rows(
-                        table, existing_node_data.table_by_type[table.type]
+                        table,
+                        state.existing_data.table_by_type[table.type],
+                        state.report,
                     )
             except MolgenisRequestError as e:
                 raise EricError(f"Error deleting rows from {table.type.base_id}") from e
 
-    def _delete_rows(self, table: Table, existing_table: Table):
+    def _delete_rows(self, table: Table, existing_table: Table, report: ErrorReport):
         """
         Deletes rows from a combined table that are not present in the staging area's
         table. If a row is referenced from the quality info tables, it is not deleted
         but a warning will be raised.
 
         :param Table table: the staging area's table
-        :node Node node: the Node that is being published
+        :param Table existing_table: the existing rows
         """
         # Compare the ids from staging and production to see what was deleted
         staging_ids = {row["id"] for row in table.rows}
@@ -110,7 +83,7 @@ class Publisher:
                 [existing_table.rows_by_id[id_]["pid"] for id_ in deletable_ids]
             )
 
-        # Actually delete the rows in the combined tables
+        # Actually delete the rows in the combined table
         if deletable_ids:
             self.printer.print(
                 f"Deleting {len(deletable_ids)} row(s) in {table.type.base_id}"
@@ -126,4 +99,7 @@ class Publisher:
                         f"the quality info: {table.type.value} {id_}."
                     )
                     self.printer.print_warning(warning)
-                    self.warnings.append(warning)
+
+                    code = existing_table.rows_by_id[id_]["national_node"]
+                    node = report.get_node(code)
+                    report.add_warnings(node, [warning])

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -43,7 +43,7 @@ class Publisher:
         for table in state.data_to_publish.import_order:
             self.printer.print(f"Upserting rows in {table.type.base_id}")
             try:
-                self.session.upsert_batched(table.type.base_id, table.rows)
+                self.session.upsert(table.type.base_id, table.rows)
             except MolgenisRequestError as e:
                 raise EricError(f"Error upserting rows to {table.type.base_id}") from e
 

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -125,5 +125,4 @@ class Publisher:
                     self.printer.print_warning(warning)
 
                     code = existing_table.rows_by_id[id_]["national_node"]
-                    node = report.get_node(code)
-                    report.add_node_warnings(node, [warning])
+                    report.add_node_warnings(Node.of(code), [warning])

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -1,10 +1,30 @@
+from dataclasses import dataclass
+from typing import List
+
 from molgenis.bbmri_eric.bbmri_client import EricSession
-from molgenis.bbmri_eric.eric import PublishingState
 from molgenis.bbmri_eric.errors import EricError, EricWarning, ErrorReport
-from molgenis.bbmri_eric.model import QualityInfo, Table, TableType
+from molgenis.bbmri_eric.model import (
+    EricData,
+    Node,
+    NodeData,
+    QualityInfo,
+    Table,
+    TableType,
+)
 from molgenis.bbmri_eric.pid_manager import BasePidManager
 from molgenis.bbmri_eric.printer import Printer
 from molgenis.client import MolgenisRequestError
+
+
+@dataclass
+class PublishingState:
+    existing_data: EricData
+    eu_node_data: NodeData
+    quality_info: QualityInfo
+    report: ErrorReport
+    publisher: "Publisher"
+    nodes: List[Node]
+    data_to_publish: EricData
 
 
 class Publisher:

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -69,7 +69,6 @@ class Publisher:
 
     def _delete_data(self, state):
         for table in reversed(state.data_to_publish.import_order):
-            self.printer.print(f"Deleting rows in {table.type.base_id}")
             try:
                 with self.printer.indentation():
                     self._delete_rows(

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -4,7 +4,7 @@ from typing import List
 from molgenis.bbmri_eric.bbmri_client import EricSession
 from molgenis.bbmri_eric.errors import EricError, EricWarning, ErrorReport
 from molgenis.bbmri_eric.model import (
-    EricData,
+    MixedData,
     Node,
     NodeData,
     QualityInfo,
@@ -18,13 +18,13 @@ from molgenis.client import MolgenisRequestError
 
 @dataclass
 class PublishingState:
-    existing_data: EricData
+    existing_data: MixedData
     eu_node_data: NodeData
     quality_info: QualityInfo
     report: ErrorReport
     publisher: "Publisher"
     nodes: List[Node]
-    data_to_publish: EricData
+    data_to_publish: MixedData
 
 
 class Publisher:

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -123,4 +123,4 @@ class Publisher:
 
                     code = existing_table.rows_by_id[id_]["national_node"]
                     node = report.get_node(code)
-                    report.add_warnings(node, [warning])
+                    report.add_node_warnings(node, [warning])

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -74,9 +74,7 @@ class Publisher:
             try:
                 with self.printer.indentation():
                     self._delete_rows(
-                        table,
-                        state.existing_data.table_by_type[table.type],
-                        state.report,
+                        table, state.existing_data.table_by_type[table.type], state
                     )
             except MolgenisRequestError as e:
                 raise EricError(f"Error deleting rows from {table.type.base_id}") from e

--- a/src/molgenis/bbmri_eric/publisher.py
+++ b/src/molgenis/bbmri_eric/publisher.py
@@ -23,11 +23,10 @@ class PublishingState:
     eu_node_data: NodeData
     quality_info: QualityInfo
     nodes: List[Node]
-    report: ErrorReport = field(init=False)
+    report: ErrorReport
     data_to_publish: MixedData = field(init=False)
 
     def __post_init__(self):
-        self.report = ErrorReport(self.nodes)
         self.data_to_publish = MixedData.from_empty(Source.TRANSFORMED)
 
 

--- a/src/molgenis/bbmri_eric/stager.py
+++ b/src/molgenis/bbmri_eric/stager.py
@@ -20,7 +20,7 @@ class Stager:
         """
         Stages all data from the provided external node in the BBMRI-ERIC directory.
         """
-        self.printer.print(f"🗑 Clearing staging area of {node.code}")
+        self.printer.print(f"🔥 Clearing staging area of {node.code}")
         self._clear_staging_area(node)
 
         self.printer.print(

--- a/src/molgenis/bbmri_eric/stager.py
+++ b/src/molgenis/bbmri_eric/stager.py
@@ -54,7 +54,7 @@ class Stager:
                 target_name = node.get_staging_id(table.type)
 
                 self.printer.print(f"Importing data to {target_name}")
-                self.session.add_batched(
+                self.session.add_all(
                     target_name, utils.remove_one_to_manys(table.rows, table.meta)
                 )
         except MolgenisRequestError as e:

--- a/src/molgenis/bbmri_eric/stager.py
+++ b/src/molgenis/bbmri_eric/stager.py
@@ -1,9 +1,7 @@
-from molgenis.bbmri_eric import utils
 from molgenis.bbmri_eric.bbmri_client import EricSession, ExternalServerSession
-from molgenis.bbmri_eric.errors import EricError
-from molgenis.bbmri_eric.model import ExternalServerNode, TableType
+from molgenis.bbmri_eric.errors import requests_error_handler
+from molgenis.bbmri_eric.model import ExternalServerNode, NodeData, TableType
 from molgenis.bbmri_eric.printer import Printer
-from molgenis.client import MolgenisRequestError
 
 
 class Stager:
@@ -16,46 +14,36 @@ class Stager:
         self.session = session
         self.printer = printer
 
+    @requests_error_handler
     def stage(self, node: ExternalServerNode):
         """
         Stages all data from the provided external node in the BBMRI-ERIC directory.
         """
-        self.printer.print(f"🔥 Clearing staging area of {node.code}")
+        source_data = self._get_source_data(node)
         self._clear_staging_area(node)
+        self._import_node(source_data)
 
-        self.printer.print(
-            f"📩 Importing data from {node.url} to staging area of {node.code}"
-        )
-        with self.printer.indentation():
-            self._import_node(node)
+    def _get_source_data(self, node: ExternalServerNode) -> NodeData:
+        """
+        Gets a node's data form an external server.
+        """
+        self.printer.print(f"📦 Retrieving node's data from {node.url}")
+        source_session = ExternalServerSession(node=node)
+        return source_session.get_node_data()
 
     def _clear_staging_area(self, node: ExternalServerNode):
         """
         Deletes all data in the staging area of an external node.
         """
-        try:
-            for table_type in reversed(TableType.get_import_order()):
-                self.session.delete(node.get_staging_id(table_type))
-        except MolgenisRequestError as e:
-            raise EricError(f"Error clearing staging area of node {node.code}") from e
+        self.printer.print(f"🔥 Clearing staging area of {node.code}")
+        for table_type in reversed(TableType.get_import_order()):
+            self.session.delete(node.get_staging_id(table_type))
 
-    def _import_node(self, node: ExternalServerNode):
+    def _import_node(self, source_data: NodeData):
         """
-        Copies the data from the external server to the staging area.
+        Imports an external node's data to its staging area.
         """
-        try:
-            source_session = ExternalServerSession(node=node)
-            source_data = source_session.get_node_data()
-        except MolgenisRequestError as e:
-            raise EricError(f"Error getting data from {node.url}") from e
-
-        try:
-            for table in source_data.import_order:
-                target_name = node.get_staging_id(table.type)
-
-                self.printer.print(f"Importing data to {target_name}")
-                self.session.add_all(
-                    target_name, utils.remove_one_to_manys(table.rows, table.meta)
-                )
-        except MolgenisRequestError as e:
-            raise EricError(f"Error copying from {node.url} to staging area") from e
+        self.printer.print(
+            f"💾 Saving data to the staging area of {source_data.node.code}"
+        )
+        self.session.import_as_csv(source_data.convert_to_staging())

--- a/src/molgenis/bbmri_eric/stager.py
+++ b/src/molgenis/bbmri_eric/stager.py
@@ -55,9 +55,7 @@ class Stager:
 
                 self.printer.print(f"Importing data to {target_name}")
                 self.session.add_batched(
-                    target_name,
-                    table.meta.self_references,
-                    utils.remove_one_to_manys(table.rows, table.meta),
+                    target_name, utils.remove_one_to_manys(table.rows, table.meta)
                 )
         except MolgenisRequestError as e:
             raise EricError(f"Error copying from {node.url} to staging area") from e

--- a/src/molgenis/bbmri_eric/transformer.py
+++ b/src/molgenis/bbmri_eric/transformer.py
@@ -25,7 +25,7 @@ class Transformer:
         self.eu_node_data = eu_node_data
         self.warnings = []
 
-    def enrich(self):
+    def transform(self):
         """
         Transforms the data of a node:
         1. Sets the commercial use boolean

--- a/src/molgenis/bbmri_eric/utils.py
+++ b/src/molgenis/bbmri_eric/utils.py
@@ -35,7 +35,7 @@ def to_upload_format(rows: List[dict]) -> List[dict]:
 def remove_one_to_manys(rows: List[dict], meta: TableMeta) -> List[dict]:
     """
     Removes all one-to-manys from a list of rows based on the table's metadata. Removing
-    one-to-manys is necessary when addingnew rows. Returns a copy so that the original
+    one-to-manys is necessary when adding new rows. Returns a copy so that the original
     rows are not changed in any way.
     """
     copied_rows = copy.deepcopy(rows)

--- a/src/molgenis/bbmri_eric/utils.py
+++ b/src/molgenis/bbmri_eric/utils.py
@@ -1,8 +1,6 @@
 import copy
 from typing import List
 
-import pandas as pd
-
 from molgenis.bbmri_eric.model import TableMeta
 
 
@@ -45,39 +43,7 @@ def remove_one_to_manys(rows: List[dict], meta: TableMeta) -> List[dict]:
     return copied_rows
 
 
-def sort_self_references(rows: List[dict], self_references: List[str]) -> List[dict]:
-    """
-    Make sure rows with a self-referencing column are added after the rows
-    with the reference
-    """
-    df = pd.DataFrame(rows)
-
-    # If all rows have a missing value for the self_referencing column, it won't be in
-    # the DataFrame
-    ref_columns = list(set(self_references).intersection(df.columns))
-
-    if ref_columns:
-        df.sort_values(by=ref_columns, na_position="first", inplace=True)
-
-    # Turn pd.DataFrame into list of dictionaries again
-    sorted_data = df.to_dict("records")
-
-    # Remove missing (NaN) values
-    for row in sorted_data:
-        for column in df.columns:
-            if isnan(row[column]):
-                del row[column]
-
-    return sorted_data
-
-
 def batched(list_: List, batch_size: int):
     """Yield successive n-sized batches from list_."""
     for i in range(0, len(list_), batch_size):
         yield list_[i : i + batch_size]
-
-
-def isnan(value):
-    # A NaN implemented following the standard, is the only value for which
-    # the inequality comparison with itself should return True:
-    return value != value

--- a/src/molgenis/bbmri_eric/utils.py
+++ b/src/molgenis/bbmri_eric/utils.py
@@ -41,9 +41,3 @@ def remove_one_to_manys(rows: List[dict], meta: TableMeta) -> List[dict]:
         for one_to_many in meta.one_to_manys:
             row.pop(one_to_many, None)
     return copied_rows
-
-
-def batched(list_: List, batch_size: int):
-    """Yield successive n-sized batches from list_."""
-    for i in range(0, len(list_), batch_size):
-        yield list_[i : i + batch_size]

--- a/src/molgenis/bbmri_eric/utils.py
+++ b/src/molgenis/bbmri_eric/utils.py
@@ -1,7 +1,4 @@
-import copy
 from typing import List
-
-from molgenis.bbmri_eric.model import TableMeta
 
 
 def to_upload_format(rows: List[dict]) -> List[dict]:
@@ -28,16 +25,3 @@ def to_upload_format(rows: List[dict]) -> List[dict]:
 
         upload_format.append(row)
     return upload_format
-
-
-def remove_one_to_manys(rows: List[dict], meta: TableMeta) -> List[dict]:
-    """
-    Removes all one-to-manys from a list of rows based on the table's metadata. Removing
-    one-to-manys is necessary when adding new rows. Returns a copy so that the original
-    rows are not changed in any way.
-    """
-    copied_rows = copy.deepcopy(rows)
-    for row in copied_rows:
-        for one_to_many in meta.one_to_manys:
-            row.pop(one_to_many, None)
-    return copied_rows

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 from molgenis.bbmri_eric.eric import Eric
 from molgenis.bbmri_eric.model import NodeData
-from molgenis.bbmri_eric.publisher import Publisher
 
 
 @pytest.fixture
@@ -47,8 +46,3 @@ def eric(session, printer, pid_service) -> Eric:
     eric = Eric(session, pid_service)
     eric.printer = printer
     return eric
-
-
-@pytest.fixture
-def publisher(session, printer, pid_service) -> Publisher:
-    return Publisher(session, printer, pid_service)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 import pkg_resources
 import pytest
 
-from molgenis.bbmri_eric.eric import Eric
 from molgenis.bbmri_eric.model import NodeData
 
 
@@ -39,10 +38,3 @@ def pid_service() -> MagicMock:
     service = MagicMock()
     service.base_url = "url/"
     return service
-
-
-@pytest.fixture
-def eric(session, printer, pid_service) -> Eric:
-    eric = Eric(session, pid_service)
-    eric.printer = printer
-    return eric

--- a/tests/test_eric.py
+++ b/tests/test_eric.py
@@ -1,12 +1,11 @@
 from typing import List
-from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from molgenis.bbmri_eric.eric import Eric
-from molgenis.bbmri_eric.errors import EricError, EricWarning, ErrorReport
-from molgenis.bbmri_eric.model import ExternalServerNode, Node, NodeData, Source
+from molgenis.bbmri_eric.errors import EricError, ErrorReport
+from molgenis.bbmri_eric.model import ExternalServerNode, Node
 from molgenis.bbmri_eric.publisher import PublishingState
 
 
@@ -17,83 +16,84 @@ def report_init():
 
 
 @pytest.fixture
-def stager_init():
-    with patch("molgenis.bbmri_eric.eric.Stager") as stager_mock:
-        yield stager_mock
+def eric(session, printer, pid_service) -> Eric:
+    eric = Eric(session, pid_service)
+    eric.printer = printer
+    eric.stager = MagicMock()
+    eric.preparator = MagicMock()
+    eric.pid_manager = MagicMock()
+    eric.publisher = MagicMock()
+    return eric
 
 
-@pytest.fixture
-def validator_init():
-    with patch("molgenis.bbmri_eric.eric.Validator") as validator_mock:
-        yield validator_mock
-
-
-@pytest.fixture
-def publisher_init():
-    with patch("molgenis.bbmri_eric.eric.Publisher") as publisher_mock:
-        yield publisher_mock
-
-
-@pytest.fixture
-def transformer_init():
-    with patch("molgenis.bbmri_eric.eric.Transformer") as transformer_mock:
-        yield transformer_mock
-
-
-@pytest.fixture
-def pid_manager_factory():
-    with patch(
-        "molgenis.bbmri_eric.eric.PidManagerFactory"
-    ) as pid_manager_factory_mock:
-        yield pid_manager_factory_mock
-
-
-def test_stage_external_nodes(stager_init, eric, printer):
+def test_stage_external_nodes(eric):
     error = EricError("error")
-    stager_init.return_value.stage.side_effect = [None, error]
+    eric.stager.stage.side_effect = [None, error]
     nl = ExternalServerNode("NL", "will succeed", "url.nl")
     be = ExternalServerNode("BE", "wil fail", "url.be")
 
     report = eric.stage_external_nodes([nl, be])
 
-    assert printer.print_node_title.mock_calls == [mock.call(nl), mock.call(be)]
-    assert stager_init.mock_calls == [
-        mock.call(eric.session, eric.printer),
-        mock.call().stage(nl),
-        mock.call(eric.session, eric.printer),
-        mock.call().stage(be),
-    ]
+    assert eric.printer.print_node_title.mock_calls == [call(nl), call(be)]
+    assert eric.stager.stage.mock_calls == [call(nl), call(be)]
     assert nl not in report.node_errors
     assert report.node_errors[be] == error
-    printer.print_summary.assert_called_once_with(report)
+    eric.printer.print_summary.assert_called_once_with(report)
 
 
-def test_publish_node_staging_fails(
-    eric,
-    session,
-    report_init,
-    stager_init,
-    validator_init,
-    publisher_init,
-):
+def test_publish_node_staging_fails(eric, session, report_init):
     nl = ExternalServerNode("NL", "Netherlands", "url")
     state = _setup_state([nl], eric, report_init)
 
     error = EricError("error")
-    stager_init.return_value.stage.side_effect = error
+    eric.stager.stage.side_effect = error
 
     report = eric.publish_nodes([nl])
 
     eric.printer.print_node_title.assert_called_once_with(nl)
-    stager_init.assert_called_with(session, eric.printer)
-    stager_init.return_value.stage.assert_called_with(nl)
+    eric.stager.stage.assert_called_with(nl)
     assert not session.get_published_node_data.called
-    assert not validator_init.called
-    publisher_init.assert_called_with(
-        session, eric.printer, state.quality_info, eric.pid_manager
-    )
-    assert publisher_init.return_value.publish.called_with(state)
+    assert not eric.preparator.prepare.called
+    assert eric.publisher.publish.called_with(state)
+    assert len(state.data_to_publish.biobanks.rows_by_id) == 0
     assert report.node_errors[nl] == error
+    eric.printer.print_summary.assert_called_once_with(report)
+
+
+def test_publish_node_prepare_fails(eric, report_init):
+    nl = ExternalServerNode("NL", "Netherlands", "url")
+    state = _setup_state([nl], eric, report_init)
+
+    error = EricError("error")
+    eric.preparator.prepare.side_effect = error
+
+    report = eric.publish_nodes([nl])
+
+    eric.printer.print_node_title.assert_called_once_with(nl)
+    eric.stager.stage.assert_called_with(nl)
+    assert eric.publisher.publish.called_with(state)
+    assert report.node_errors[nl] == error
+    eric.printer.print_summary.assert_called_once_with(report)
+
+
+def test_publish_nodes(eric, report_init):
+    no = Node("NO", "succeeds")
+    nl = ExternalServerNode("NL", "fails during publishing", "url")
+    state = _setup_state([no, nl], eric, report_init)
+
+    error = EricError("error")
+    eric.publisher.publish.side_effect = error
+
+    report = eric.publish_nodes([no, nl])
+
+    assert eric.printer.print_node_title.mock_calls == [call(no), call(nl)]
+    eric.preparator.prepare.assert_has_calls(
+        [call(no, state), call(nl, state)], any_order=True
+    )
+    eric.publisher.publish.assert_called_with(state)
+    assert len(report.node_errors) == 0
+    assert report.error == error
+    assert len(report.node_warnings) == 0
     eric.printer.print_summary.assert_called_once_with(report)
 
 
@@ -112,90 +112,3 @@ def _setup_state(nodes: List[Node], eric: Eric, report_init):
     eric._init_state = MagicMock()
     eric._init_state.return_value = state
     return state
-
-
-def test_publish_node_get_data_fails(
-    eric,
-    report_init,
-    publisher_init,
-    validator_init,
-    stager_init,
-    session,
-):
-    nl = ExternalServerNode("NL", "Netherlands", "url")
-    state = _setup_state([nl], eric, report_init)
-
-    error = EricError("error")
-    session.get_staging_node_data.side_effect = error
-
-    report = eric.publish_nodes([nl])
-
-    eric.printer.print_node_title.assert_called_once_with(nl)
-    publisher_init.assert_called_with(
-        session, eric.printer, state.quality_info, eric.pid_manager
-    )
-    stager_init.assert_called_with(session, eric.printer)
-    stager_init.return_value.stage.assert_called_with(nl)
-    session.get_staging_node_data.assert_called_with(nl)
-    assert not validator_init.called
-    assert publisher_init.return_value.publish.called_with(state)
-    assert report.node_errors[nl] == error
-    eric.printer.print_summary.assert_called_once_with(report)
-
-
-def test_publish_nodes(
-    eric,
-    pid_service,
-    pid_manager_factory,
-    report_init,
-    publisher_init,
-    validator_init,
-    stager_init,
-    transformer_init,
-    session,
-):
-    no = Node("NO", "succeeds with validation warnings")
-    nl = ExternalServerNode("NL", "fails during publishing", "url")
-    state = _setup_state([no, nl], eric, report_init)
-
-    pid_manager = MagicMock()
-    pid_manager_factory.create.return_value = pid_manager
-    pid_manager.assign_biobank_pids.return_value = []
-    no_data = _mock_node_data(no)
-    nl_data = _mock_node_data(nl)
-    session.get_staging_node_data.side_effect = [no_data, nl_data]
-    warning = EricWarning("warning")
-    validator_init.return_value.validate.side_effect = [[warning], []]
-    transformer_init.return_value.transform.return_value = []
-
-    report = eric.publish_nodes([no, nl])
-
-    assert eric.printer.print_node_title.mock_calls == [mock.call(no), mock.call(nl)]
-    stager_init.assert_called_with(session, eric.printer)
-    stager_init.return_value.stage.assert_called_with(nl)
-    assert validator_init.mock_calls == [
-        mock.call(no_data, eric.printer),
-        mock.call().validate(),
-        mock.call(nl_data, eric.printer),
-        mock.call().validate(),
-    ]
-    assert publisher_init.mock_calls == [
-        mock.call(session, eric.printer, state.quality_info, eric.pid_manager),
-        mock.call().publish(state),
-    ]
-    assert no not in report.node_errors
-    assert nl not in report.node_errors
-    assert nl not in report.node_warnings
-    assert report.node_warnings[no] == [warning]
-    eric.printer.print_summary.assert_called_once_with(report)
-
-
-def _mock_node_data(node: Node):
-    return NodeData(
-        node=node,
-        source=Source.STAGING,
-        persons=MagicMock(),
-        biobanks=MagicMock(),
-        networks=MagicMock(),
-        collections=MagicMock(),
-    )

--- a/tests/test_eric.py
+++ b/tests/test_eric.py
@@ -40,8 +40,8 @@ def test_stage_external_nodes(stager_init, eric, printer):
         mock.call(eric.session, eric.printer),
         mock.call().stage(be),
     ]
-    assert nl not in report.errors
-    assert report.errors[be] == error
+    assert nl not in report.node_errors
+    assert report.node_errors[be] == error
     printer.print_summary.assert_called_once_with(report)
 
 
@@ -66,7 +66,7 @@ def test_publish_node_staging_fails(
     assert not session.get_published_node_data.called
     assert not validator_init.called
     assert not publisher_init.return_value.publish.called
-    assert report.errors[nl] == error
+    assert report.node_errors[nl] == error
     eric.printer.print_summary.assert_called_once_with(report)
 
 
@@ -91,7 +91,7 @@ def test_publish_node_get_data_fails(
     session.get_staging_node_data.assert_called_with(nl)
     assert not validator_init.called
     assert not publisher_init.return_value.publish.called
-    assert report.errors[nl] == error
+    assert report.node_errors[nl] == error
     eric.printer.print_summary.assert_called_once_with(report)
 
 
@@ -124,10 +124,10 @@ def test_publish_nodes(
         mock.call().publish(no_data),
         mock.call().publish(nl_data),
     ]
-    assert no not in report.errors
-    assert report.errors[nl] == error
-    assert nl not in report.warnings
-    assert report.warnings[no] == [warning]
+    assert no not in report.node_errors
+    assert report.node_errors[nl] == error
+    assert nl not in report.node_warnings
+    assert report.node_warnings[no] == [warning]
     eric.printer.print_summary.assert_called_once_with(report)
 
 

--- a/tests/test_eric.py
+++ b/tests/test_eric.py
@@ -1,10 +1,19 @@
+from typing import List
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from molgenis.bbmri_eric.errors import EricError, EricWarning
+from molgenis.bbmri_eric.eric import Eric
+from molgenis.bbmri_eric.errors import EricError, EricWarning, ErrorReport
 from molgenis.bbmri_eric.model import ExternalServerNode, Node, NodeData, Source
+from molgenis.bbmri_eric.publisher import PublishingState
+
+
+@pytest.fixture
+def report_init():
+    with patch("molgenis.bbmri_eric.eric.ErrorReport") as report_mock:
+        yield report_mock
 
 
 @pytest.fixture
@@ -23,6 +32,20 @@ def validator_init():
 def publisher_init():
     with patch("molgenis.bbmri_eric.eric.Publisher") as publisher_mock:
         yield publisher_mock
+
+
+@pytest.fixture
+def transformer_init():
+    with patch("molgenis.bbmri_eric.eric.Transformer") as transformer_mock:
+        yield transformer_mock
+
+
+@pytest.fixture
+def pid_manager_factory():
+    with patch(
+        "molgenis.bbmri_eric.eric.PidManagerFactory"
+    ) as pid_manager_factory_mock:
+        yield pid_manager_factory_mock
 
 
 def test_stage_external_nodes(stager_init, eric, printer):
@@ -48,65 +71,102 @@ def test_stage_external_nodes(stager_init, eric, printer):
 def test_publish_node_staging_fails(
     eric,
     session,
-    pid_service,
+    report_init,
     stager_init,
     validator_init,
     publisher_init,
 ):
     nl = ExternalServerNode("NL", "Netherlands", "url")
+    state = _setup_state([nl], eric, report_init)
+
     error = EricError("error")
     stager_init.return_value.stage.side_effect = error
 
     report = eric.publish_nodes([nl])
 
     eric.printer.print_node_title.assert_called_once_with(nl)
-    publisher_init.assert_called_with(session, eric.printer, pid_service)
     stager_init.assert_called_with(session, eric.printer)
     stager_init.return_value.stage.assert_called_with(nl)
     assert not session.get_published_node_data.called
     assert not validator_init.called
-    assert not publisher_init.return_value.publish.called
+    publisher_init.assert_called_with(
+        session, eric.printer, state.quality_info, eric.pid_manager
+    )
+    assert publisher_init.return_value.publish.called_with(state)
     assert report.node_errors[nl] == error
     eric.printer.print_summary.assert_called_once_with(report)
 
 
+# noinspection PyProtectedMember
+def _setup_state(nodes: List[Node], eric: Eric, report_init):
+    report = ErrorReport(nodes)
+    report_init.return_value = report
+
+    state = PublishingState(
+        existing_data=MagicMock(),
+        eu_node_data=MagicMock(),
+        quality_info=MagicMock(),
+        nodes=nodes,
+        report=report,
+    )
+    eric._init_state = MagicMock()
+    eric._init_state.return_value = state
+    return state
+
+
 def test_publish_node_get_data_fails(
     eric,
-    pid_service,
+    report_init,
     publisher_init,
     validator_init,
     stager_init,
     session,
 ):
     nl = ExternalServerNode("NL", "Netherlands", "url")
+    state = _setup_state([nl], eric, report_init)
+
     error = EricError("error")
     session.get_staging_node_data.side_effect = error
 
     report = eric.publish_nodes([nl])
 
     eric.printer.print_node_title.assert_called_once_with(nl)
-    publisher_init.assert_called_with(session, eric.printer, pid_service)
+    publisher_init.assert_called_with(
+        session, eric.printer, state.quality_info, eric.pid_manager
+    )
     stager_init.assert_called_with(session, eric.printer)
     stager_init.return_value.stage.assert_called_with(nl)
     session.get_staging_node_data.assert_called_with(nl)
     assert not validator_init.called
-    assert not publisher_init.return_value.publish.called
+    assert publisher_init.return_value.publish.called_with(state)
     assert report.node_errors[nl] == error
     eric.printer.print_summary.assert_called_once_with(report)
 
 
 def test_publish_nodes(
-    eric, pid_service, publisher_init, validator_init, stager_init, session
+    eric,
+    pid_service,
+    pid_manager_factory,
+    report_init,
+    publisher_init,
+    validator_init,
+    stager_init,
+    transformer_init,
+    session,
 ):
     no = Node("NO", "succeeds with validation warnings")
     nl = ExternalServerNode("NL", "fails during publishing", "url")
+    state = _setup_state([no, nl], eric, report_init)
+
+    pid_manager = MagicMock()
+    pid_manager_factory.create.return_value = pid_manager
+    pid_manager.assign_biobank_pids.return_value = []
     no_data = _mock_node_data(no)
     nl_data = _mock_node_data(nl)
     session.get_staging_node_data.side_effect = [no_data, nl_data]
     warning = EricWarning("warning")
     validator_init.return_value.validate.side_effect = [[warning], []]
-    error = EricError("error")
-    publisher_init.return_value.publish.side_effect = [[], error]
+    transformer_init.return_value.transform.return_value = []
 
     report = eric.publish_nodes([no, nl])
 
@@ -120,12 +180,11 @@ def test_publish_nodes(
         mock.call().validate(),
     ]
     assert publisher_init.mock_calls == [
-        mock.call(session, eric.printer, pid_service),
-        mock.call().publish(no_data),
-        mock.call().publish(nl_data),
+        mock.call(session, eric.printer, state.quality_info, eric.pid_manager),
+        mock.call().publish(state),
     ]
     assert no not in report.node_errors
-    assert report.node_errors[nl] == error
+    assert nl not in report.node_errors
     assert nl not in report.node_warnings
     assert report.node_warnings[no] == [warning]
     eric.printer.print_summary.assert_called_once_with(report)
@@ -139,5 +198,4 @@ def _mock_node_data(node: Node):
         biobanks=MagicMock(),
         networks=MagicMock(),
         collections=MagicMock(),
-        table_by_type=MagicMock(),
     )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -45,6 +45,13 @@ def test_error_report():
     assert report.has_warnings()
 
 
+def test_error_report_global_error():
+    report = ErrorReport([])
+    assert not report.has_errors()
+    report.set_global_error(EricError())
+    assert report.has_errors()
+
+
 def test_requests_error_handler():
     exception = requests.exceptions.ConnectionError()
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -30,17 +30,17 @@ def test_error_report():
     assert not report.has_errors()
     assert not report.has_warnings()
 
-    report.add_error(a, error)
+    report.add_node_error(a, error)
 
-    assert report.errors[a] == error
-    assert b not in report.errors
+    assert report.node_errors[a] == error
+    assert b not in report.node_errors
     assert report.has_errors()
     assert not report.has_warnings()
 
-    report.add_warnings(b, [warning, warning])
+    report.add_node_warnings(b, [warning, warning])
 
-    assert report.warnings[b] == [warning, warning]
-    assert a not in report.warnings
+    assert report.node_warnings[b] == [warning, warning]
+    assert a not in report.node_warnings
     assert report.has_errors()
     assert report.has_warnings()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -81,13 +81,12 @@ def test_node_data_order():
     node = Node("NL", "NL")
 
     node_data = NodeData(
-        node,
+        node=node,
         source=Source.STAGING,
         persons=persons,
         networks=networks,
         biobanks=biobanks,
         collections=collections,
-        table_by_type=MagicMock(),
     )
 
     assert node_data.import_order == [persons, networks, biobanks, collections]

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -123,10 +123,10 @@ def test_print_summary(capsys):
     report = ErrorReport(nodes)
     warning = EricWarning("warning")
     error = EricError("error")
-    report.add_warnings(c, [warning])
-    report.add_warnings(d, [warning, warning])
-    report.add_error(b, error)
-    report.add_error(c, error)
+    report.add_node_warnings(c, [warning])
+    report.add_node_warnings(d, [warning, warning])
+    report.add_node_error(b, error)
+    report.add_node_error(c, error)
 
     Printer().print_summary(report)
 

--- a/tests/test_publication_preparer.py
+++ b/tests/test_publication_preparer.py
@@ -1,0 +1,134 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from molgenis.bbmri_eric.errors import EricWarning, ErrorReport
+from molgenis.bbmri_eric.model import Node
+from molgenis.bbmri_eric.publication_preparer import PublicationPreparer
+
+
+@pytest.fixture
+def validator_init():
+    with patch("molgenis.bbmri_eric.publication_preparer.Validator") as validator_mock:
+        yield validator_mock
+
+
+@pytest.fixture
+def transformer_init():
+    with patch(
+        "molgenis.bbmri_eric.publication_preparer.Transformer"
+    ) as transformer_mock:
+        yield transformer_mock
+
+
+@pytest.fixture
+def pid_manager():
+    return MagicMock()
+
+
+@pytest.fixture
+def preparer(session, printer, pid_manager):
+    return PublicationPreparer(printer, pid_manager, session)
+
+
+def test_prepare(preparer, session):
+    validate_func = MagicMock()
+    preparer._validate_node = validate_func
+    transform_func = MagicMock()
+    preparer._transform_node = transform_func
+    manage_pids_func = MagicMock()
+    preparer._manage_node_pids = manage_pids_func
+    nl = Node.of("NL")
+    state = MagicMock()
+    report = MagicMock()
+    state.report = report
+    node_data = MagicMock()
+    session.get_staging_node_data.return_value = node_data
+
+    preparer.prepare(nl, state)
+
+    session.get_staging_node_data.assert_called_with(nl)
+    validate_func.assert_called_with(node_data, report)
+    transform_func.assert_called_with(node_data, state)
+    manage_pids_func.assert_called_with(node_data, state)
+
+
+def test_validate(preparer: PublicationPreparer, validator_init, printer):
+    validator = MagicMock()
+    validator_init.return_value = validator
+    node_data = MagicMock()
+    report = MagicMock()
+
+    preparer._validate_node(node_data, report)
+
+    validator_init.assert_called_with(node_data, printer)
+    assert validator.validate.called
+
+
+def test_validate_warnings(preparer: PublicationPreparer, validator_init, printer):
+    validator = MagicMock()
+    validator_init.return_value = validator
+    warning = EricWarning("warning")
+    validator.validate.return_value = [warning]
+    node_data = MagicMock()
+    nl = Node.of("NL")
+    node_data.node = nl
+    report: ErrorReport = ErrorReport([nl])
+
+    preparer._validate_node(node_data, report)
+
+    assert report.node_warnings[nl] == [warning]
+
+
+def test_transform(preparer: PublicationPreparer, transformer_init):
+    transformer = MagicMock()
+    transformer_init.return_value = transformer
+
+    preparer._transform_node(MagicMock(), MagicMock())
+
+    assert transformer_init.called
+    assert transformer.transform.called
+
+
+def test_transform_warnings(preparer: PublicationPreparer, transformer_init, printer):
+    transformer = MagicMock()
+    transformer_init.return_value = transformer
+    warning = EricWarning("warning")
+    transformer.transform.return_value = [warning]
+    node_data = MagicMock()
+    nl = Node.of("NL")
+    node_data.node = nl
+    state = MagicMock()
+    state.report = ErrorReport(nl)
+
+    preparer._transform_node(node_data, state)
+
+    assert state.report.node_warnings[nl] == [warning]
+
+
+def test_manage_pids(preparer, transformer_init, pid_manager):
+    biobanks = MagicMock()
+    node_data = MagicMock()
+    node_data.biobanks = biobanks
+    existing_biobanks = MagicMock()
+    state = MagicMock()
+    state.existing_data.biobanks = existing_biobanks
+
+    preparer._manage_node_pids(node_data, state)
+
+    pid_manager.assign_biobank_pids.assert_called_with(biobanks)
+    pid_manager.update_biobank_pids.assert_called_with(biobanks, existing_biobanks)
+
+
+def test_manage_pids_warning(preparer, transformer_init, pid_manager):
+    nl = Node.of("NL")
+    node_data = MagicMock()
+    node_data.node = nl
+    state = MagicMock()
+    state.report = ErrorReport([nl])
+    warning = EricWarning("warning")
+    pid_manager.assign_biobank_pids.return_value = [warning]
+
+    preparer._manage_node_pids(node_data, state)
+
+    assert state.report.node_warnings[nl] == [warning]

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -55,19 +55,11 @@ def test_publish(publisher, session):
 
     assert publisher._delete_rows.mock_calls == [
         mock.call(
-            state.data_to_publish.collections,
-            state.existing_data.collections,
-            state.report,
+            state.data_to_publish.collections, state.existing_data.collections, state
         ),
-        mock.call(
-            state.data_to_publish.biobanks, state.existing_data.biobanks, state.report
-        ),
-        mock.call(
-            state.data_to_publish.networks, state.existing_data.networks, state.report
-        ),
-        mock.call(
-            state.data_to_publish.persons, state.existing_data.persons, state.report
-        ),
+        mock.call(state.data_to_publish.biobanks, state.existing_data.biobanks, state),
+        mock.call(state.data_to_publish.networks, state.existing_data.networks, state),
+        mock.call(state.data_to_publish.persons, state.existing_data.persons, state),
     ]
 
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -18,7 +18,7 @@ def pid_manager_factory():
 
 @pytest.fixture
 def publisher(session, printer, pid_service) -> Publisher:
-    return Publisher(session, printer, MagicMock(), pid_service)
+    return Publisher(session, printer, pid_service)
 
 
 def test_publish(publisher, session):
@@ -72,9 +72,6 @@ def test_publish(publisher, session):
 
 
 def test_delete_rows(publisher, pid_service, node_data: NodeData, session):
-    publisher.quality_info = QualityInfo(
-        biobanks={"undeletable_id": ["quality"]}, collections={}
-    )
     existing_biobanks_table = MagicMock()
     existing_biobanks_table.rows_by_id.return_value = {
         "bbmri-eric:ID:NO_OUS": {"pid": "pid1"},
@@ -86,9 +83,13 @@ def test_delete_rows(publisher, pid_service, node_data: NodeData, session):
         "delete_this_row",
         "undeletable_id",
     }
-    report = ErrorReport([Node.of("NO")])
+    state: PublishingState = MagicMock()
+    state.quality_info = QualityInfo(
+        biobanks={"undeletable_id": ["quality"]}, collections={}
+    )
+    state.report = ErrorReport([Node.of("NO")])
 
-    publisher._delete_rows(node_data.biobanks, existing_biobanks_table, report)
+    publisher._delete_rows(node_data.biobanks, existing_biobanks_table, state)
 
     publisher.pid_manager.terminate_biobanks(["pid2"])
     session.delete_list.assert_called_with(

--- a/tests/test_stager.py
+++ b/tests/test_stager.py
@@ -71,22 +71,18 @@ def test_import_node(external_server_init, node_data: NodeData):
     assert session.add_batched.mock_calls == [
         mock.call(
             "eu_bbmri_eric_NO_persons",
-            node_data.persons.meta.self_references,
             utils.remove_one_to_manys(node_data.persons.rows, node_data.persons.meta),
         ),
         mock.call(
             "eu_bbmri_eric_NO_networks",
-            node_data.networks.meta.self_references,
             utils.remove_one_to_manys(node_data.networks.rows, node_data.networks.meta),
         ),
         mock.call(
             "eu_bbmri_eric_NO_biobanks",
-            node_data.biobanks.meta.self_references,
             utils.remove_one_to_manys(node_data.biobanks.rows, node_data.biobanks.meta),
         ),
         mock.call(
             "eu_bbmri_eric_NO_collections",
-            node_data.collections.meta.self_references,
             utils.remove_one_to_manys(
                 node_data.collections.rows, node_data.collections.meta
             ),

--- a/tests/test_stager.py
+++ b/tests/test_stager.py
@@ -61,14 +61,14 @@ def test_import_node(external_server_init, node_data: NodeData):
     source_session_mock_instance = external_server_init.return_value
     source_session_mock_instance.get_node_data.return_value = node_data
     session = EricSession("url")
-    session.add_batched = MagicMock(name="add_batched")
+    session.add_all = MagicMock(name="add_all")
     node = ExternalServerNode("NO", "Norway", "url")
 
     Stager(session, Printer())._import_node(node)
 
     external_server_init.assert_called_with(node=node)
     source_session_mock_instance.get_node_data.assert_called_once()
-    assert session.add_batched.mock_calls == [
+    assert session.add_all.mock_calls == [
         mock.call(
             "eu_bbmri_eric_NO_persons",
             utils.remove_one_to_manys(node_data.persons.rows, node_data.persons.meta),
@@ -106,8 +106,8 @@ def test_import_node_copy_node_error(external_server_init, node_data: NodeData):
     source_session_mock_instance = external_server_init.return_value
     source_session_mock_instance.get_node_data.return_value = node_data
     session = EricSession("url")
-    session.add_batched = MagicMock(name="add_batched")
-    session.add_batched.side_effect = MolgenisRequestError("error")
+    session.add_all = MagicMock(name="add_all")
+    session.add_all.side_effect = MolgenisRequestError("error")
     node = ExternalServerNode("NO", "Norway", "url")
 
     with pytest.raises(EricError) as e:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 from molgenis.bbmri_eric import utils
@@ -90,44 +89,3 @@ def test_remove_one_to_manys(meta):
         },
         {"id": "collB"},
     ]
-
-
-def test_sort_self_references():
-    self_references = ["parent_collection"]
-    rows = [
-        {
-            "id": "collA",
-            "name": "CollectionA",
-            "parent_collection": "collB",
-        },
-        {"id": "collB", "name": "CollectionB"},
-        {"id": "collC", "name": "CollectionC"},
-        {"id": "collD", "name": "CollectionD", "parent_collection": "collA"},
-        {"id": "collE", "name": "CollectionE", "parent_collection": "collB"},
-    ]
-
-    assert utils.sort_self_references(rows, self_references) == [
-        {
-            "id": "collB",
-            "name": "CollectionB",
-        },
-        {
-            "id": "collC",
-            "name": "CollectionC",
-        },
-        {"id": "collD", "name": "CollectionD", "parent_collection": "collA"},
-        {"id": "collA", "name": "CollectionA", "parent_collection": "collB"},
-        {"id": "collE", "name": "CollectionE", "parent_collection": "collB"},
-    ]
-
-
-def test_isnan():
-    x1 = np.nan
-    x2 = "test"
-    x3 = ["test1", "test2"]
-    x4 = np.NaN
-
-    assert utils.isnan(x1) is True
-    assert utils.isnan(x2) is False
-    assert utils.isnan(x3) is False
-    assert utils.isnan(x4) is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,21 +71,3 @@ def test_to_upload_format(rows):
         },
         {"id": "collB", "sub_collections": ["collA"]},
     ]
-
-
-def test_remove_one_to_manys(meta):
-    rows = [
-        {
-            "id": "collA",
-            "parent_collection": "collB",
-            "sub_collections": [],
-        },
-        {"id": "collB", "sub_collections": ["collA"]},
-    ]
-    assert utils.remove_one_to_manys(rows, meta) == [
-        {
-            "id": "collA",
-            "parent_collection": "collB",
-        },
-        {"id": "collB"},
-    ]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -110,10 +110,10 @@ def mock_node_data():
         Node("NL", "NL"),
         Source.STAGING,
         {
-            TableType.PERSONS: persons,
-            TableType.NETWORKS: networks,
-            TableType.BIOBANKS: biobanks,
-            TableType.COLLECTIONS: collections,
+            TableType.PERSONS.value: persons,
+            TableType.NETWORKS.value: networks,
+            TableType.BIOBANKS.value: biobanks,
+            TableType.COLLECTIONS.value: collections,
         },
     )
 


### PR DESCRIPTION
Changes:
- Removes the batch add/upload/upsert methods because they are no longer needed with the increased limit
- Instead of publishing each node separately, collects every node's data and publishes it at once. This decreases the amount of requests, shortening the indexing time needed by 6x.
- Imports the combined data using the Import API instead of the REST API which also improves performance.
- Refactoring to improve testability and reduce complexity:
```mermaid
graph TD
    A(Eric) --> B(1. Stager)
    A --> C(2. PublicationPreparer)
    A --> D(3. Publisher)
    C --> E(Validator)
    C --> F(Transformer)
    C --> G(PID Manager)
```


#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] Updated CHANGELOG.md
