### PR TITLE
chore: Remove check on multiple age_units as datatype is categorical now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Version 1.13.0 (development)
 - Map matching disease codes to categories
+- Remove check on multiple age_units as datatype has changed to categorical
 
 ## Version 1.12.0
 - Include publishing of Facts tables

--- a/src/molgenis/bbmri_eric/validation.py
+++ b/src/molgenis/bbmri_eric/validation.py
@@ -81,11 +81,6 @@ class Validator:
         high = collection.get("age_high", None)
         unit = collection.get("age_unit", None)
 
-        if unit and len(unit) > 1:
-            self._warn(
-                f"Collection {collection['id']} has more than one age_unit: {unit}"
-            )
-
         if low == 0 and high == 0:
             self._warn(
                 f"Collection {collection['id']} has invalid ages: age_low = 0 and "

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -115,17 +115,17 @@ def test_validate_id(node_data):
     "collection,expected",
     [
         (dict(), []),
-        ({"id": "0", "age_low": 0, "age_unit": ["YEAR"]}, []),
+        ({"id": "0", "age_low": 0, "age_unit": "YEAR"}, []),
         (
-            {"id": "1", "age_low": 0, "age_unit": ["YEAR", "MONTH"]},
-            [EricWarning("Collection 1 has more than one age_unit: ['YEAR', 'MONTH']")],
+            {"id": "1", "age_low": 0, "age_unit": "YEAR"},
+            [],
         ),
         (
             {"id": "2", "age_low": 5},
             [EricWarning("Collection 2 has age_low/age_high without age_unit")],
         ),
         (
-            {"id": "3", "age_low": 0, "age_high": 0, "age_unit": ["YEAR"]},
+            {"id": "3", "age_low": 0, "age_high": 0, "age_unit": "YEAR"},
             [
                 EricWarning(
                     "Collection 3 has invalid ages: age_low = 0 and age_high = " "0"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -117,10 +117,6 @@ def test_validate_id(node_data):
         (dict(), []),
         ({"id": "0", "age_low": 0, "age_unit": "YEAR"}, []),
         (
-            {"id": "1", "age_low": 0, "age_unit": "YEAR"},
-            [],
-        ),
-        (
             {"id": "2", "age_low": 5},
             [EricWarning("Collection 2 has age_low/age_high without age_unit")],
         ),


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [ ] Code reviewed
- [x] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [x] Updated CHANGELOG.md
