### PR TITLE
feat: RD-category also based on collection_type = RD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## Version 1.14.0 (development)
+- Besides adding the RD category to collections having "ORPHA" diagnosis_available, now
+  also collection having collection type = RD (and no ORPHA or other (than ORPHA)
+  diagnosis_available) get the RD-category assigned.
 
 ## Version 1.13.1
 - Fix error in staging: Also known in should be emptied after networks and not before

--- a/src/molgenis/bbmri_eric/categories.py
+++ b/src/molgenis/bbmri_eric/categories.py
@@ -68,8 +68,9 @@ class CategoryMapper:
 
         self._map_paediatric(collection, categories)
         self._map_diseases(collection, categories)
+        self._map_collection_types(collection, categories)
 
-        return categories
+        return list(set(categories))
 
     @classmethod
     def _map_paediatric(cls, collection: dict, categories: List[str]):
@@ -90,6 +91,11 @@ class CategoryMapper:
                 categories.append(Category.PAEDIATRIC.value)
             elif low is not None and (low < age_limit):
                 categories.append(Category.PAEDIATRIC_INCLUDED.value)
+
+    @classmethod
+    def _map_collection_types(cls, collection: dict, categories: List[str]):
+        if "RD" in collection.get("type", []):
+            categories.append(Category.RARE_DISEASE.value)
 
     def _map_diseases(self, collection: dict, categories: List[str]):
         diagnoses = deepcopy(collection.get("diagnosis_available", []))

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -99,3 +99,17 @@ def test_map_diseases(mapper, disease_ontology, collection: dict, expected: List
     categories = []
     mapper._map_diseases(collection, categories)
     assert categories == expected
+
+
+@pytest.mark.parametrize(
+    "collection,expected",
+    [
+        (dict(), []),
+        ({"type": ["DISEASE_SPECIFIC"]}, []),
+        ({"type": ["RD"]}, [Category.RARE_DISEASE.value]),
+    ],
+)
+def test_map_collection_types(mapper, collection: dict, expected: List[str]):
+    categories = []
+    mapper._map_collection_types(collection, categories)
+    assert categories == expected


### PR DESCRIPTION
Besides adding the RD category to collections having "ORPHA" diagnosis_available, now also collection having collection type = RD (and no ORPHA or other (than ORPHA) diagnosis_available) get the RD-category assigned.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [x] Updated CHANGELOG.md
