### PR TITLE
chore: fix RSQL "and" query

### DIFF
--- a/scripts/hook_acc.py
+++ b/scripts/hook_acc.py
@@ -86,7 +86,7 @@ def overwrite_pids(session: EricSession, logger):
     logger.info("Making biobanks PID column temporarily editable (readonly=false)")
 
     pid_attr_id = session.get(
-        "sys_md_Attribute", q="name==pid&&entity==eu_bbmri_eric_biobanks"
+        "sys_md_Attribute", q="name==pid;entity==eu_bbmri_eric_biobanks"
     )[0]["id"]
 
     response = session._session.patch(

--- a/scripts/hook_testnn.py
+++ b/scripts/hook_testnn.py
@@ -84,7 +84,7 @@ def overwrite_pids(session: EricSession, logger):
     logger.info("Making biobanks PID column temporarily editable (readonly=false)")
 
     pid_attr_id = session.get(
-        "sys_md_Attribute", q="name==pid&&entity==eu_bbmri_eric_biobanks"
+        "sys_md_Attribute", q="name==pid;entity==eu_bbmri_eric_biobanks"
     )[0]["id"]
 
     response = session._session.patch(


### PR DESCRIPTION
It turned out that there was an error in one of the RSQL queries including an "AND" operator.

#### Checklist
- [x] Functionality works & meets specifications
- [ ] Code reviewed
- [x] Code unit/system tested (Not necessary)
- [x] User documentation updated (Not necessary)
- [ ] Clean commits
- [x] Updated CHANGELOG.md (Not necessary)
