### PR TITLE
feat: get staging data from external servers iso published data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-## Version 1.17.0 (development)
+## Version 1.18.0 (development)
+
+## Version 1.17.0
+- Get staging data instead of published data from the external servers
 
 ## Version 1.16.1
 - Fix error when deleting biobanks with no PID (issue #68)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                 }
                 container('vault') {
                     script {
-                        env.PYPI_USERNAME = sh(script: 'vault kv get -mount=secret -field=token_username secret/data/ops/account/pypi', returnStdout: true)
+                        env.PYPI_USERNAME = sh(script: 'vault kv get -field=token_username secret/data/ops/account/pypi', returnStdout: true)
                         env.PYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/pypi', returnStdout: true)
                         env.TESTPYPI_USERNAME = sh(script: 'vault kv get -mount=secret -field=token_username secret/data/ops/account/testpypi', returnStdout: true)
                         env.TESTPYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/testpypi', returnStdout: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,12 +15,12 @@ pipeline {
                 }
                 container('vault') {
                     script {
-                        env.PYPI_USERNAME = sh(script: 'vault read -field=token_username secret/ops/account/pypi', returnStdout: true)
-                        env.PYPI_PASSWORD = sh(script: 'vault read -field=API_token secret/ops/account/pypi', returnStdout: true)
-                        env.TESTPYPI_USERNAME = sh(script: 'vault read -field=token_username secret/ops/account/testpypi', returnStdout: true)
-                        env.TESTPYPI_PASSWORD = sh(script: 'vault read -field=API_token secret/ops/account/testpypi', returnStdout: true)
-                        env.GITHUB_TOKEN = sh(script: 'vault read -field=value secret/ops/token/github', returnStdout: true)
-                        env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
+                        env.PYPI_USERNAME = sh(script: 'vault read -field=token_username secret/data/ops/account/pypi', returnStdout: true)
+                        env.PYPI_PASSWORD = sh(script: 'vault read -field=API_token secret/data/ops/account/pypi', returnStdout: true)
+                        env.TESTPYPI_USERNAME = sh(script: 'vault read -field=token_username secret/data/ops/account/testpypi', returnStdout: true)
+                        env.TESTPYPI_PASSWORD = sh(script: 'vault read -field=API_token secret/data/ops/account/testpypi', returnStdout: true)
+                        env.GITHUB_TOKEN = sh(script: 'vault read -field=value secret/data/ops/token/github', returnStdout: true)
+                        env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/data/ops/token/sonar', returnStdout: true)
                     }
                 }
                 container('python') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                 }
                 container('vault') {
                     script {
-                        env.PYPI_USERNAME = sh(script: 'vault kv get -field=token_username secret/data/ops/account/pypi', returnStdout: true)
+                        env.PYPI_USERNAME = sh(script: 'vault kv get -field=token_username secret/ops/account/pypi', returnStdout: true)
                         env.PYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/pypi', returnStdout: true)
                         env.TESTPYPI_USERNAME = sh(script: 'vault kv get -mount=secret -field=token_username secret/data/ops/account/testpypi', returnStdout: true)
                         env.TESTPYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/testpypi', returnStdout: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,12 +15,12 @@ pipeline {
                 }
                 container('vault') {
                     script {
-                        env.PYPI_USERNAME = sh(script: 'vault read -field=token_username secret/data/ops/account/pypi', returnStdout: true)
-                        env.PYPI_PASSWORD = sh(script: 'vault read -field=API_token secret/data/ops/account/pypi', returnStdout: true)
-                        env.TESTPYPI_USERNAME = sh(script: 'vault read -field=token_username secret/data/ops/account/testpypi', returnStdout: true)
-                        env.TESTPYPI_PASSWORD = sh(script: 'vault read -field=API_token secret/data/ops/account/testpypi', returnStdout: true)
-                        env.GITHUB_TOKEN = sh(script: 'vault read -field=value secret/data/ops/token/github', returnStdout: true)
-                        env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/data/ops/token/sonar', returnStdout: true)
+                        env.PYPI_USERNAME = sh(script: 'vault kv get -mount=secret -field=token_username secret/data/ops/account/pypi', returnStdout: true)
+                        env.PYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/pypi', returnStdout: true)
+                        env.TESTPYPI_USERNAME = sh(script: 'vault kv get -mount=secret -field=token_username secret/data/ops/account/testpypi', returnStdout: true)
+                        env.TESTPYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/testpypi', returnStdout: true)
+                        env.GITHUB_TOKEN = sh(script: 'vault kv get -mount=secret -field=value secret/data/ops/token/github', returnStdout: true)
+                        env.SONAR_TOKEN = sh(script: 'vault kv get -mount=secret -field=value secret/data/ops/token/sonar', returnStdout: true)
                     }
                 }
                 container('python') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,11 +16,11 @@ pipeline {
                 container('vault') {
                     script {
                         env.PYPI_USERNAME = sh(script: 'vault kv get -field=token_username secret/ops/account/pypi', returnStdout: true)
-                        env.PYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/pypi', returnStdout: true)
-                        env.TESTPYPI_USERNAME = sh(script: 'vault kv get -mount=secret -field=token_username secret/data/ops/account/testpypi', returnStdout: true)
-                        env.TESTPYPI_PASSWORD = sh(script: 'vault kv get -mount=secret -field=API_token secret/data/ops/account/testpypi', returnStdout: true)
-                        env.GITHUB_TOKEN = sh(script: 'vault kv get -mount=secret -field=value secret/data/ops/token/github', returnStdout: true)
-                        env.SONAR_TOKEN = sh(script: 'vault kv get -mount=secret -field=value secret/data/ops/token/sonar', returnStdout: true)
+                        env.PYPI_PASSWORD = sh(script: 'vault kv get -field=API_token secret/ops/account/pypi', returnStdout: true)
+                        env.TESTPYPI_USERNAME = sh(script: 'vault kv get -field=token_username secret/ops/account/testpypi', returnStdout: true)
+                        env.TESTPYPI_PASSWORD = sh(script: 'vault kv get -field=API_token secret/ops/account/testpypi', returnStdout: true)
+                        env.GITHUB_TOKEN = sh(script: 'vault kv get -field=value secret/ops/token/github', returnStdout: true)
+                        env.SONAR_TOKEN = sh(script: 'vault kv get -field=value secret/ops/token/sonar', returnStdout: true)
                     }
                 }
                 container('python') {

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -3,17 +3,20 @@ Example usage file meant for development. Make sure you have an .env file and a
 pyhandle_creds.json file in this folder.
 """
 
-from dotenv import dotenv_values
+import os
+
+from dotenv import load_dotenv
 
 from molgenis.bbmri_eric.bbmri_client import EricSession
 from molgenis.bbmri_eric.eric import Eric
 from molgenis.bbmri_eric.pid_service import PidService
 
 # Get credentials from .env
-config = dotenv_values(".env")
-target = config["TARGET"]
-username = config["USERNAME"]
-password = config["PASSWORD"]
+load_dotenv()
+
+target = os.getenv("TARGET")
+username = os.getenv("USERNAME")
+password = os.getenv("PASSWORD")
 
 # Login to the directory with an EricSession
 session = EricSession(url=target)

--- a/src/molgenis/bbmri_eric/bbmri_client.py
+++ b/src/molgenis/bbmri_eric/bbmri_client.py
@@ -1,3 +1,4 @@
+import os
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -204,6 +205,7 @@ class EricSession(Session):
                         description=node["description"],
                         date_end=node.get("date_end"),
                         url=node["dns"],
+                        token=os.getenv(node["id"]),
                     )
                 )
         return result
@@ -315,8 +317,8 @@ class ExternalServerSession(Session):
     A session with a national node's external server (for example BBMRI-NL).
     """
 
-    def __init__(self, node: ExternalServerNode, *args, **kwargs):
-        super().__init__(url=node.url, *args, **kwargs)
+    def __init__(self, node: ExternalServerNode):
+        super().__init__(url=node.url, token=node.token)
         self.node = node
 
     def get_node_data(self) -> NodeData:
@@ -328,7 +330,7 @@ class ExternalServerSession(Session):
 
         tables = dict()
         for table_type in TableType.get_import_order():
-            id_ = table_type.base_id
+            id_ = self.node.get_staging_id(table_type)
             if not self.get("sys_md_EntityType", q=f"id=={id_}"):
                 tables[table_type.value] = Table.of_placeholder(table_type)
             else:

--- a/src/molgenis/bbmri_eric/model.py
+++ b/src/molgenis/bbmri_eric/model.py
@@ -219,7 +219,7 @@ class Node:
     @classmethod
     def get_eu_id_prefix(cls, table_type: TableType) -> str:
         """
-        Some nodes can refer to rows in the EU node. These rows have an EU prefix and
+        Some nodes can refer to rows in the EU node. These rows have an EU prefix, and
         it's based on the classifier of the table.
 
         :param TableType table_type: the table to get the EU id prefix for
@@ -247,6 +247,7 @@ class ExternalServerNode(Node):
     """Represents a node that has an external server on which its data is hosted."""
 
     url: str | None = None
+    token: str | None = None
 
 
 class Source(Enum):

--- a/src/molgenis/bbmri_eric/pid_manager.py
+++ b/src/molgenis/bbmri_eric/pid_manager.py
@@ -137,7 +137,7 @@ class PidManagerFactory:
 
     @staticmethod
     def create(pid_service: BasePidService, printer: Printer) -> BasePidManager:
-        if type(pid_service) == NoOpPidService:
+        if type(pid_service) is NoOpPidService:
             return NoOpPidManager()
         else:
             return PidManager(pid_service, printer)

--- a/src/molgenis/bbmri_eric/stager.py
+++ b/src/molgenis/bbmri_eric/stager.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from molgenis.bbmri_eric.bbmri_client import EricSession, ExternalServerSession
-from molgenis.bbmri_eric.errors import EricWarning, requests_error_handler
+from molgenis.bbmri_eric.errors import EricError, EricWarning, requests_error_handler
 from molgenis.bbmri_eric.model import ExternalServerNode, NodeData, TableType
 from molgenis.bbmri_eric.printer import Printer
 
@@ -33,19 +33,34 @@ class Stager:
     def _get_source_data(self, node: ExternalServerNode) -> NodeData:
         """
         Gets a node's data from an external server.
-        First check if all tables are available
+        First check if:
+        - the session has the right permissions
+        - and if all tables are available
         """
         self.printer.print(f"📦 Retrieving node's data from {node.url}")
         source_session = ExternalServerSession(node=node)
+        self._check_permissions(source_session)
         self._check_tables(source_session)
         return source_session.get_node_data()
+
+    @staticmethod
+    def _check_permissions(session: ExternalServerSession):
+        """
+        Check if the session has the necessary permissions
+        """
+        package = f"eu_bbmri_eric_{session.node.code}"
+        if not session.get("sys_md_Package", q=f"id=={package}"):
+            raise EricError(
+                "The session user has invalid permissions\n       Please check the "
+                "token and permissions of this user"
+            )
 
     def _check_tables(self, session: ExternalServerSession):
         """
         Check if all tables are available on the external server
         """
         for table_type in TableType.get_import_order():
-            id_ = table_type.base_id
+            id_ = session.node.get_staging_id(table_type)
             if not session.get("sys_md_EntityType", q=f"id=={id_}"):
                 warning = EricWarning(
                     f"Node {session.node.code} has no {table_type.value} table"


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [ ] Code reviewed
- [x] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [x] Updated CHANGELOG.md

To get data from the staging areas of external servers login credentials (a token) and permissions are needed. These credentials need to be stored in a .env file on the server where the data is going to be staged.
The stager includes a check if the token is valid and if the user having this token has the right permissions.
