### PR TITLE
chore: setup circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ workflows:
   build_and_test:
     when:
       and:
-        - equal [false, << pipeline.parameters.release >>]
+        - equal [true, <<pipeline.parameters.release>>]
     jobs:
       - run_tests
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,13 @@ jobs:
       - run: git checkout -f main
       - run: git fetch --tags
       # bump the version based on the last tag and create a new tag
+      - run: RELEASE_SCOPE=patch
       - run:
           command: |
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo $NEW_PACKAGE_VERSION
       - run: git checkout .
-      - run: RELEASE_SCOPE=patch
       - run: # build and publish the release
           command: |
             tox -e build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,9 @@ jobs:
           name: Build and publish the release to testpypi
           command: |
             tox -e build
-            tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-          # Voor testen even --skip-existing toegevoegd
-          # Met PR werkt pushen van tag niet
+            tox -e publish -- --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
+          # Voor testen --skip-existing toegevoegd
+          # Met PR werkt pushen van tags niet, even afwachten of met main goed gaat
 #      - run: git push --tags origin main
       - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
@@ -87,17 +87,15 @@ jobs:
       - run: pip install tox
       - attach_workspace:
           at: ~/repo
-      # do the actual release to PyPi
-      - run: cat bash.env >> $BASH_ENV
       - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
+      - run: cat bash.env >> $BASH_ENV
       - run:
           name: Message slack about the release
           command: |
             curl -d "token=${SLACK_TOKEN}" \
-            -d "text= TEST-TEST-TEST-TEST RELEASE molgenis-py-bbmri-eric TO PYPI" \
+            -d "text=molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
             -d "channel=C013UDLKFEW" \
             -X POST https://slack.com/api/chat.postMessage
-      #      -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
 
 workflows:
   build_and_test:
@@ -115,7 +113,7 @@ workflows:
             - run_tests
           filters:
             branches:
-              only: circleci-project-setup # moet zijn main, maar voor testen ff zo
+              only: main
       - release2pypi?:
           type: approval
           requires:
@@ -123,7 +121,7 @@ workflows:
             - release2testpypi
           filters:
             branches:
-              only: circleci-project-setup # moet zijn main, maar voor testen ff zo
+              only: main
       - release2pypi:
           requires:
             - run_tests
@@ -131,4 +129,4 @@ workflows:
             - release2pypi?
           filters:
             branches:
-              only: circleci-project-setup
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,8 @@ jobs:
             echo release scope is << pipeline.parameters.release_scope >>
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
             pip install bumpversion
-            echo 'export NEW_PACKAGE_VERSION=$(bash bump-version.sh)' >> "$BASH_ENV"
+            NEW_PACKAGE_VERSION=$(bash bump-version.sh)
+            echo "export NEW_PACKAGE_VERSION=$NEW_PACKAGE_VERSION" >> "$BASH_ENV"
             echo new version is $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release
@@ -98,10 +99,10 @@ jobs:
       - run:
           command: |
             echo scope is $RELEASE_SCOPE
-            echo $NEW_PACKAGE_VERSION
+            echo $NEW_VERSION
             TEST=hoi
             echo $TEST
-      - run: echo in release new version is $NEW_PACKAGE_VERSION
+      - run: echo in release new version is $NEW_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
  #     - run:
  #         name: message slack about the release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,11 @@ jobs:
           name: Bump the version based on the last tag and create a new tag
           command: |
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
-            echo $RELEASE_SCOPE
+            echo release_scope is $RELEASE_SCOPE
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
-            echo $NEW_PACKAGE_VERSION
+            echo \n new version is $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release
           command: |
@@ -94,7 +94,7 @@ jobs:
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
       - run: cat bash.env >> $BASH_ENV
-      - run: echo $NEW_PACKAGE_VERSION
+      - run: echo in release new version is $NEW_PACKAGE_VERSION
  #     - run:
  #         name: message slack about the release
  #         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
     executor: my-executor
     steps:
       - checkout
+      - run: echo << pipeline.parameters.release >>
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
     working_directory: ~/repo
 
 jobs:
-  build_and_test
+  build_and_test:
     executor: my-executor    
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
-            echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
+            echo 'export NEW_PACKAGE_VERSION=$NEW_PACKAGE_VERSION' >> "$BASH_ENV"
             echo new version is $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           root: ~/repo
           paths:
             -  .
-            -  ~/repo/workspace/bash.env
+            -  workspace/bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,10 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet
@@ -82,6 +86,8 @@ jobs:
     steps:
       - checkout
       - run: pip install tox
+      - attach_workspace:
+          at: ~/repo
       # do the actual release to PyPi
       # Maar gaat waarschijnlijk niet goed omdat het een andere env is. Iets met workspace doen?
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 
 jobs:
   build_and_test:
-    executor: my-executor    
+    executor: my-executor
     steps:
       - checkout
       - run: pip install tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           command: |
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
+            echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
             echo $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,10 @@ jobs:
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: cat bash.env >> $BASH_ENV
+      - run:
+          command: |
+            TEST=$NEW_PACKAGE_VERSION
+            echo $TEST
       - run: echo in release new version is $NEW_PACKAGE_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
  #     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,8 @@ jobs:
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
           # Voor testen even --skip-existing toegevoegd
-          # push the new tag to molgenis/molgenis-py-bbmri-eric
-      - run:
-          name: Update tags
-          command: |
-            git checkout main
-            git push --tags origin main
+          # Met PR werkt pushen van tag niet
+#      - run: git push --tags origin main
       - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: ~/repo
@@ -92,16 +88,16 @@ jobs:
       - attach_workspace:
           at: ~/repo
       # do the actual release to PyPi
-      # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: cat bash.env >> $BASH_ENV
-      - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
+      - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run:
           name: Message slack about the release
           command: |
             curl -d "token=${SLACK_TOKEN}" \
-            -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
+            -d "text= TEST-TEST-TEST-TEST RELEASE molgenis-py-bbmri-eric TO PYPI" \
             -d "channel=C013UDLKFEW" \
             -X POST https://slack.com/api/chat.postMessage
+      #      -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
 
 workflows:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
     working_directory: ~/repo
 
 jobs:
-  tests:
+  run_tests:
     executor: my-executor
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run: # build and publish the release
           command: |
             tox -e build
-            tox -e publish -- --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
+            tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
 
           # push the new tag to molgenis/molgenis-py-bbmri-eric
       # - run: git push --tags origin main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,9 @@ jobs:
       - run:
           name: Bump the version based on the last tag and create a new tag
           command: |
-            echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
-            printenv RELEASE_SCOPE
+            RELEASE_SCOPE=<< pipeline.parameters.release_scope >>
+            echo release scope is $RELEASE_SCOPE
+            echo 'export RELEASE_SCOPE' >> "$BASH_ENV"
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,8 @@ jobs:
       - run: git checkout -f main
       - run: git fetch --tags
       # bump the version based on the last tag and create a new tag
-      - run: RELEASE_SCOPE=patch
+      - run: echo 'export RELEASE_SCOPE="patch"' >> "$BASH_ENV"
+      - run: echo $RELEASE_SCOPE
       - run:
           command: |
             pip install bumpversion

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,8 @@ jobs:
           name: Build and publish the release to testpypi
           command: |
             tox -e build
-            tox -e publish -- --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-          # Voor testen --skip-existing toegevoegd
-          # Met PR werkt pushen van tags niet, even afwachten of met main goed gaat
-#      - run: git push --tags origin main
+            tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
+      - run: git push --tags origin main
       - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: ~/repo
@@ -87,7 +85,7 @@ jobs:
       - run: pip install tox
       - attach_workspace:
           at: ~/repo
-      - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
+      - run: tox -e publish -- --skip-existing --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: cat bash.env >> $BASH_ENV
       - run:
           name: Message slack about the release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,8 @@ workflows:
   test-python-jobs:
     jobs:
       - build_and_test
-      - hold:
+      - release2testpypi?:
+          description: Release to testpypi?
           type: approval
           requires:
             - build_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,7 @@ jobs:
             echo release scope is << pipeline.parameters.release_scope >>
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
             pip install bumpversion
-            NEW_PACKAGE_VERSION=$(bash bump-version.sh)
-            echo 'export NEW_VERSION=$NEW_PACKAGE_VERSION' >> "$BASH_ENV"
+            echo 'export NEW_PACKAGE_VERSION=$(bash bump-version.sh)' >> "$BASH_ENV"
             echo new version is $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release
@@ -99,10 +98,10 @@ jobs:
       - run:
           command: |
             echo scope is $RELEASE_SCOPE
-            echo $NEW_VERSION
+            echo $NEW_PACKAGE_VERSION
             TEST=hoi
             echo $TEST
-      - run: echo in release new version is $NEW_VERSION
+      - run: echo in release new version is $NEW_PACKAGE_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
  #     - run:
  #         name: message slack about the release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ~/repo
+      - run: pip install tox
       - run: tox
       - run: pre-commit run --all-files
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
     executor: my-executor
     steps:
       - checkout
-      - run: echo << pipeline.parameters.release >>
       - run:
           name: Run tests
           command: |
@@ -41,9 +40,9 @@ jobs:
             else
               echo "SONAR FOR MAIN"
             fi
-          # Iets met sonar voor PR:
+          # Actual sonar-scanner still needs to be implemented:
           # "sonar-scanner -Dsonar.github.oauth=${env.GITHUB_TOKEN} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.pullrequest.key=${env.CHANGE_ID} -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=molgenis/molgenis-py-bbmri-eric"
-            # voor main:
+            # for main:
           # "sonar-scanner"
   release2testpypi:
     executor: my-executor
@@ -56,7 +55,7 @@ jobs:
             git config user.name "dtroelofsprins"
       - run: pip install tox
       - run: echo $GITHUB_TOKEN
-      - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
+ #     - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
       - run: git checkout -f main
       - run: git fetch --tags
       - run:
@@ -93,25 +92,15 @@ jobs:
           at: ~/repo
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
-      - run: ls -l
-      - run: cat workspace/bash.env
       - run: cat workspace/bash.env >> $BASH_ENV
-      - run:
-          command: |
-            echo scope is $RELEASE_SCOPE
-            echo $NEW_PACKAGE_VERSION
-            TEST=hoi
-            echo $TEST
-      - run: echo in release new version is $NEW_PACKAGE_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
- #     - run:
- #         name: message slack about the release
- #         command: |
- #           curl -d "token=${SLACK_TOKEN}" \
- #           -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
- #           -d "channel=C01TN8FU480" \
- #           -X POST https://slack.com/api/chat.postMessage
-
+ ##     - run:
+  #        name: message slack about the release
+  #        command: |
+  #          curl -d "token=${SLACK_TOKEN}" \
+  ##          -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
+   #         -d "channel=C01TN8FU480" \
+   #         -X POST https://slack.com/api/chat.postMessage
 
 workflows:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo $NEW_PACKAGE_VERSION
       - run: git checkout .
-      - run: RELEASE_SCOPE = patch
+      - run: RELEASE_SCOPE=patch
       - run: # build and publish the release
           command: |
             tox -e build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
     working_directory: ~/repo
 
 jobs:
-  run_tests:
+  tests:
     executor: my-executor
     steps:
       - checkout
@@ -94,7 +94,7 @@ jobs:
 
 
 workflows:
-  run_tests:
+  test:
     jobs:
       - run_tests
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,11 @@ jobs:
           name: Bump the version based on the last tag and create a new tag
           command: |
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
-            echo release_scope is ${RELEASE_SCOPE}
+            echo release_scope is "$RELEASE_SCOPE"
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
-            echo "\n new version is" $NEW_PACKAGE_VERSION
+            echo '\n new version is ${NEW_PACKAGE_VERSION}'
       - run: git checkout .
       - run: # build and publish the release
           command: |
@@ -77,6 +77,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            -  .
             - bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
-            echo 'export NEW_PACKAGE_VERSION=$NEW_PACKAGE_VERSION' >> "$BASH_ENV"
+            echo 'export NEW_VERSION=$NEW_PACKAGE_VERSION' >> "$BASH_ENV"
             echo new version is $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release
@@ -99,10 +99,10 @@ jobs:
       - run:
           command: |
             echo scope is $RELEASE_SCOPE
-            echo $NEW_PACKAGE_VERSION
+            echo $NEW_VERSION
             TEST=hoi
             echo $TEST
-      - run: echo in release new version is $NEW_PACKAGE_VERSION
+      - run: echo in release new version is $NEW_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
  #     - run:
  #         name: message slack about the release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,36 +48,37 @@ jobs:
     executor: my-executor
     steps:
       - checkout
- #     - run:
- #         name: Setup git
- #         command: |
- #           git config user.email "d.t.roelofs-prins@umcg.nl"
- #           git config user.name "dtroelofsprins"
       - run: pip install tox
- #     - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
+      - run:
+          # Could be replaced by adding a public/private ssh key
+          name: Setup git config
+          command: |
+            git config user.email "d.t.roelofs-prins@umcg.nl"
+            git config user.name "dtroelofsprins"
+ #   Seems not necessary used in Jenkins file  - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
       - run: git checkout -f main
       - run: git fetch --tags
       - run:
           name: Bump the version based on the last tag and create a new tag
           command: |
-            echo release scope is << pipeline.parameters.release_scope >>
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo "export NEW_PACKAGE_VERSION=$NEW_PACKAGE_VERSION" >> "$BASH_ENV"
-            echo new version is $NEW_PACKAGE_VERSION
+            echo New Package version is $NEW_PACKAGE_VERSION
       - run: git checkout .
-      - run: # build and publish the release
+      - run:
+          name: Build and publish the release to testpypi
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-      - run: mkdir -p workspace
-      - run: cp $BASH_ENV workspace/bash.env
+    #  - run: mkdir -p workspace
+      - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: ~/repo
           paths:
             -  .
-            -  workspace/bash.env
+          #  -  workspace/bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet
@@ -91,9 +92,10 @@ jobs:
           at: ~/repo
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
-      - run: cat workspace/bash.env >> $BASH_ENV
+      - run: cat bash.env >> $BASH_ENV
+      - run: echo $NEW_PACKAGE_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
- ##     - run:
+  #    - run:
   #        name: message slack about the release
   #        command: |
   #          curl -d "token=${SLACK_TOKEN}" \
@@ -117,7 +119,7 @@ workflows:
             - run_tests
           filters:
             branches:
-              only: circleci-project-setup # moet zijn main (master?), maar voor testen ff zo
+              only: circleci-project-setup # moet zijn main, maar voor testen ff zo
       - release2pypi?:
           type: approval
           requires:
@@ -125,7 +127,7 @@ workflows:
             - release2testpypi
           filters:
             branches:
-              only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
+              only: circleci-project-setup # moet zijn main, maar voor testen ff zo
       - release2pypi:
           requires:
             - run_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,11 @@ jobs:
     executor: my-executor
     steps:
       - checkout
+      - run:
+          name: Setup git
+          command: |
+            git config user.email "d.t.roelofs-prins@umcg.nl"
+            git config user.name "dtroelofsprins"
       - run: pip install tox
       - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
       - run: git checkout -f main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
 
 
 workflows:
-  test:
+  build_and_test:
     jobs:
       - run_tests
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory in the execution
           # environment which is taken to be the root directory of the workspace.
-          root: workspace
+          root: ~/repo/workspace
           # Must be relative path from root
           paths:
           - output
@@ -28,7 +28,7 @@ jobs:
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
-          at: /repo/workspace
+          at: ~/repo/workspace
       - run: tox
       - run: pre-commit run --all-files
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,18 +67,17 @@ jobs:
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
-            echo '\n new version is ${NEW_PACKAGE_VERSION}'
+            echo new version is $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-      - run: cp $BASH_ENV bash.env
+      - run: cp $BASH_ENV ~repo/bash.env
       - persist_to_workspace:
           root: .
           paths:
             -  .
-            - bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet
@@ -89,7 +88,7 @@ jobs:
       - checkout
       - run: pip install tox
       - attach_workspace:
-          at: .
+          at: ~/repo
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,8 @@ jobs:
       - run:
           name: Bump the version based on the last tag and create a new tag
           command: |
-            RELEASE_SCOPE=<< pipeline.parameters.release_scope >>
-            echo release scope is $RELEASE_SCOPE
-            echo 'export RELEASE_SCOPE' >> "$BASH_ENV"
+            echo release scope is << pipeline.parameters.release_scope >>
+            echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,12 @@ jobs:
     executor: my-executor
     steps:
       - checkout
-      - run:
-          name: Setup git
-          command: |
-            git config user.email "d.t.roelofs-prins@umcg.nl"
-            git config user.name "dtroelofsprins"
+ #     - run:
+ #         name: Setup git
+ #         command: |
+ #           git config user.email "d.t.roelofs-prins@umcg.nl"
+ #           git config user.name "dtroelofsprins"
       - run: pip install tox
-      - run: echo $GITHUB_TOKEN
  #     - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
       - run: git checkout -f main
       - run: git fetch --tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           # "sonar-scanner -Dsonar.github.oauth=${env.GITHUB_TOKEN} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.pullrequest.key=${env.CHANGE_ID} -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=molgenis/molgenis-py-bbmri-eric"
             # voor main:
           # "sonar-scanner"
-  release:
+  release2testpypi:
     executor: my-executor
     steps:
       - checkout
@@ -94,44 +94,35 @@ jobs:
 
 
 workflows:
-  build_pr_or_release:
+  run_tests:
     jobs:
       - run_tests
-      - release:
-          requires:
-            - build_and_test
-            - release?
-          filters:
-            branches:
-              only: circleci-project-setup # moet zijn main (master?), maar voor testen ff zo
-          when:
-            or:
-              - equal: [ patch, <<pipeline.parameters.release_scope>> ]
-              - equal: [ minor, <<pipeline.parameters.release_scope>> ]
-              - equal: [ major, <<pipeline.parameters.release_scope>> ]
-      - release2pypi?:
-          type: approval
-          requires:
-            - build_and_test
-            - release
-          filters:
-            branches:
-              only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
-          when:
-            or:
-              - equal: [ patch, <<pipeline.parameters.release_scope>> ]
-              - equal: [ minor, <<pipeline.parameters.release_scope>> ]
-              - equal: [ major, <<pipeline.parameters.release_scope>> ]
-      - release2pypi:
-          requires:
-            - build_and_test
-            - release
-            - release2pypi?
-          filters:
-            branches:
-              only: circleci-project-setup
-          when:
-            or:
-              - equal: [ patch, <<pipeline.parameters.release_scope>> ]
-              - equal: [ minor, <<pipeline.parameters.release_scope>> ]
-              - equal: [ major, <<pipeline.parameters.release_scope>> ]
+  release:
+    when:
+      or:
+        - equal: [ patch, <<pipeline.parameters.release_scope>> ]
+        - equal: [ minor, <<pipeline.parameters.release_scope>> ]
+        - equal: [ major, <<pipeline.parameters.release_scope>> ]
+    jobs:
+    - release2testpypi:
+        requires:
+          - run_tests
+        filters:
+          branches:
+            only: circleci-project-setup # moet zijn main (master?), maar voor testen ff zo
+    - release2pypi?:
+        type: approval
+        requires:
+          - run_tests
+          - release2testpypi
+        filters:
+          branches:
+            only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
+    - release2pypi:
+        requires:
+          - run_tests
+          - release2testpypi
+          - release2pypi?
+        filters:
+          branches:
+            only: circleci-project-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           name: Bump the version based on the last tag and create a new tag
           command: |
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
-            echo release_scope is "$RELEASE_SCOPE"
+            printenv RELEASE_SCOPE
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
@@ -77,7 +77,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            -  .
+            -  bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet
@@ -88,12 +88,12 @@ jobs:
       - checkout
       - run: pip install tox
       - attach_workspace:
-          at: ~/repo
+          at: .
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
-      - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
       - run: cat bash.env >> $BASH_ENV
       - run: echo in release new version is $NEW_PACKAGE_VERSION
+      - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
  #     - run:
  #         name: message slack about the release
  #         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@
 # See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
+orbs:
+  sonarqube: clicklogiq/sonarqube@1.0.1
+
 parameters:
   release:
     type: boolean
@@ -85,13 +88,14 @@ jobs:
       # do the actual release to PyPi
       # Maar gaat waarschijnlijk niet goed omdat het een andere env is. Iets met workspace doen?
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
-     # - run:
-     #     name: message slack about the release
-     #     command: |
-     #       curl -d "token=${SLACK_TOKEN}" \
-     #       -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
-     #       -d "channel=C01TN8FU480" \
-     #       -X POST https://slack.com/api/chat.postMessage
+      - run: tox -e publish -- --repository testpypi --skip-existing --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_PASSWORD}
+      - run:
+          name: message slack about the release
+          command: |
+            curl -d "token=${SLACK_TOKEN}" \
+            -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
+            -d "channel=C01TN8FU480" \
+            -X POST https://slack.com/api/chat.postMessage
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
+      - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: .
           paths:
@@ -89,16 +90,17 @@ jobs:
       - attach_workspace:
           at: ~/repo
       # do the actual release to PyPi
-      # Maar gaat waarschijnlijk niet goed omdat het een andere env is. Iets met workspace doen?
-      # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
+      # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-      - run:
-          name: message slack about the release
-          command: |
-            curl -d "token=${SLACK_TOKEN}" \
-            -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
-            -d "channel=C01TN8FU480" \
-            -X POST https://slack.com/api/chat.postMessage
+      - run: cat bash.env >> $BASH_ENV
+      - run: echo $NEW_PACKAGE_VERSION
+ #     - run:
+ #         name: message slack about the release
+ #         command: |
+ #           curl -d "token=${SLACK_TOKEN}" \
+ #           -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
+ #           -d "channel=C01TN8FU480" \
+ #           -X POST https://slack.com/api/chat.postMessage
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - checkout
       - run: pip install tox
       - attach_workspace:
-          at: ~/repo
+          at: .
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
           at: ~/repo
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
+      - run: ls -l
+      - run: cat workspace/bash.env
       - run: cat workspace/bash.env >> $BASH_ENV
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,30 +95,34 @@ jobs:
 
 workflows:
   build_and_test:
+    when:
+      and:
+        - equal [false, << pipeline.parameters.release >>]
     jobs:
       - run_tests
   release:
     when: << pipeline.parameters.release >>
     jobs:
-    - release2testpypi:
-        requires:
-          - run_tests
-        filters:
-          branches:
-            only: circleci-project-setup # moet zijn main (master?), maar voor testen ff zo
-    - release2pypi?:
-        type: approval
-        requires:
-          - run_tests
-          - release2testpypi
-        filters:
-          branches:
-            only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
-    - release2pypi:
-        requires:
-          - run_tests
-          - release2testpypi
-          - release2pypi?
-        filters:
-          branches:
-            only: circleci-project-setup
+      - run_tests
+      - release2testpypi:
+          requires:
+            - run_tests
+          filters:
+            branches:
+              only: circleci-project-setup # moet zijn main (master?), maar voor testen ff zo
+      - release2pypi?:
+          type: approval
+          requires:
+            - run_tests
+            - release2testpypi
+          filters:
+            branches:
+              only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
+      - release2pypi:
+          requires:
+            - run_tests
+            - release2testpypi
+            - release2pypi?
+          filters:
+            branches:
+              only: circleci-project-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,14 @@
 # See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
+parameters:
+  release:
+    type: boolean
+    default: false
+  release_scope:
+    type: string
+    default: chore
+
 executors:
   my-executor:
     docker:
@@ -9,7 +17,7 @@ executors:
     working_directory: ~/repo
 
 jobs:
-  build_and_test:
+  run_tests:
     executor: my-executor
     steps:
       - checkout
@@ -24,12 +32,19 @@ jobs:
             pip install pre-commit
             pre-commit install
             pre-commit run --all-files
-        # Iets met sonar voor PR:
-        # "sonar-scanner -Dsonar.github.oauth=${env.GITHUB_TOKEN} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.pullrequest.key=${env.CHANGE_ID} -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=molgenis/molgenis-py-bbmri-eric"
-        # voor main:
-        # "sonar-scanner"
-
-  release2testpypi:
+      - run:
+          name: sonar
+          command: |
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              echo "SONAR FOR PR"
+            else
+              echo "SONAR FOR MAIN"
+            fi
+          # Iets met sonar voor PR:
+          # "sonar-scanner -Dsonar.github.oauth=${env.GITHUB_TOKEN} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.pullrequest.key=${env.CHANGE_ID} -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=molgenis/molgenis-py-bbmri-eric"
+            # voor main:
+          # "sonar-scanner"
+  release:
     executor: my-executor
     steps:
       - checkout
@@ -46,7 +61,7 @@ jobs:
       - run:
           name: Bump the version based on the last tag and create a new tag
           command: |
-            echo 'export RELEASE_SCOPE="patch"' >> "$BASH_ENV"
+            echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
             echo $RELEASE_SCOPE
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
@@ -57,6 +72,7 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
+          # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet
       # - run: git push --tags origin main
@@ -66,6 +82,7 @@ jobs:
       - checkout
       - run: pip install tox
       # do the actual release to PyPi
+      # Maar gaat waarschijnlijk niet goed omdat het een andere env is. Iets met workspace doen?
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
      # - run:
      #     name: message slack about the release
@@ -79,27 +96,42 @@ jobs:
 workflows:
   build_pr_or_release:
     jobs:
-      - build_and_test
-      - release?:
-          type: approval
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
-      - release2testpypi:
+      - run_tests
+      - release:
           requires:
             - build_and_test
             - release?
           filters:
             branches:
               only: circleci-project-setup # moet zijn main (master?), maar voor testen ff zo
-
+          when:
+            or:
+              - equal: [ patch, <<pipeline.parameters.release_scope>> ]
+              - equal: [ minor, <<pipeline.parameters.release_scope>> ]
+              - equal: [ major, <<pipeline.parameters.release_scope>> ]
+      - release2pypi?:
+          type: approval
+          requires:
+            - build_and_test
+            - release
+          filters:
+            branches:
+              only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
+          when:
+            or:
+              - equal: [ patch, <<pipeline.parameters.release_scope>> ]
+              - equal: [ minor, <<pipeline.parameters.release_scope>> ]
+              - equal: [ major, <<pipeline.parameters.release_scope>> ]
       - release2pypi:
           requires:
             - build_and_test
-            - release?
-            - release2testpypi
+            - release
+            - release2pypi?
           filters:
             branches:
               only: circleci-project-setup
+          when:
+            or:
+              - equal: [ patch, <<pipeline.parameters.release_scope>> ]
+              - equal: [ minor, <<pipeline.parameters.release_scope>> ]
+              - equal: [ major, <<pipeline.parameters.release_scope>> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ workflows:
   build_and_test:
     when:
       and:
-        - equal [true, <<pipeline.parameters.release>>]
+        - not: << pipeline.parameters.release >>
     jobs:
       - run_tests
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ version: 2.1
 parameters:
   release:
     type: boolean
-    default: false
+    default: true
   release_scope:
     type: string
-    default: chore
+    default: patch
 
 executors:
   my-executor:
@@ -63,17 +63,17 @@ jobs:
           name: Bump the version based on the last tag and create a new tag
           command: |
             echo 'export RELEASE_SCOPE=<< pipeline.parameters.release_scope >>' >> "$BASH_ENV"
-            echo release_scope is $RELEASE_SCOPE
+            echo release_scope is ${RELEASE_SCOPE}
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
-            echo \n new version is $NEW_PACKAGE_VERSION
+            echo "\n new version is" $NEW_PACKAGE_VERSION
       - run: git checkout .
       - run: # build and publish the release
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-      - run: cp $BASH_ENV bash.env
+      - run: cp $"BASH_ENV" bash.env
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,7 @@ jobs:
       - run:
           name: Update tags
           command: |
-            git config user.email "d.t.roelofs-prins@umcg.nl"
-            git config user.name "dtroelofsprins"
+            git checkout main
             git push --tags origin main
       - run: cp $BASH_ENV bash.env
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,10 +99,10 @@ jobs:
       - run:
           command: |
             echo scope is $RELEASE_SCOPE
-            echo $NEW_VERSION
+            echo $NEW_PACKAGE_VERSION
             TEST=hoi
             echo $TEST
-      - run: echo in release new version is $NEW_VERSION
+      - run: echo in release new version is $NEW_PACKAGE_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
  #     - run:
  #         name: message slack about the release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,6 @@
 # See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
-orbs:
-  sonarqube: clicklogiq/sonarqube@1.0.1
-
 parameters:
   release:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-      - run: cp $BASH_ENV ~repo/bash.env
+      - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,9 @@ jobs:
       - run: cat workspace/bash.env >> $BASH_ENV
       - run:
           command: |
+            echo scope is $RELEASE_SCOPE
             echo $NEW_PACKAGE_VERSION
-            TEST=$NEW_PACKAGE_VERSION
+            TEST=hoi
             echo $TEST
       - run: echo in release new version is $NEW_PACKAGE_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,17 @@ jobs:
     executor: my-executor
     steps:
       - checkout
-      - run: pip install tox
-      - run: pip install pre-commit
-      - run: pre-commit install
-      - run: tox
-      - run: pre-commit run --all-files
+      - run:
+          name: Run tests
+          command: |
+            pip install tox
+            tox
+      - run:
+          name: Install and run pre-commit
+          command: |
+            pip install pre-commit
+            pre-commit install
+            pre-commit run --all-files
         # Iets met sonar voor PR:
         # "sonar-scanner -Dsonar.github.oauth=${env.GITHUB_TOKEN} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.pullrequest.key=${env.CHANGE_ID} -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=molgenis/molgenis-py-bbmri-eric"
         # voor main:
@@ -33,14 +39,15 @@ jobs:
             git config user.email "d.t.roelofs-prins@umcg.nl"
             git config user.name "dtroelofsprins"
       - run: pip install tox
+      - run: echo $GITHUB_TOKEN
       - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
       - run: git checkout -f main
       - run: git fetch --tags
-      # bump the version based on the last tag and create a new tag
-      - run: echo 'export RELEASE_SCOPE="patch"' >> "$BASH_ENV"
-      - run: echo $RELEASE_SCOPE
       - run:
+          name: Bump the version based on the last tag and create a new tag
           command: |
+            echo 'export RELEASE_SCOPE="patch"' >> "$BASH_ENV"
+            echo $RELEASE_SCOPE
             pip install bumpversion
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo 'export NEW_PACKAGE_VERSION' >> "$BASH_ENV"
@@ -50,8 +57,8 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-
           # push the new tag to molgenis/molgenis-py-bbmri-eric
+          # Maar voor testen even nog niet
       # - run: git push --tags origin main
   release2pypi:
     executor: my-executor
@@ -60,38 +67,39 @@ jobs:
       - run: pip install tox
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
-      - run:
-          name: message slack about release and updated demo server
-          command: |
-            curl -d "token=${SLACK_TOKEN}" \
-            -d "text=molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
-            -d "channel=C01TN8FU480" \
-            -X POST https://slack.com/api/chat.postMessage
+     # - run:
+     #     name: message slack about the release
+     #     command: |
+     #       curl -d "token=${SLACK_TOKEN}" \
+     #       -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
+     #       -d "channel=C01TN8FU480" \
+     #       -X POST https://slack.com/api/chat.postMessage
 
 
 workflows:
   build_pr_or_release:
     jobs:
       - build_and_test
-      - release2testpypi:
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              only: circleci-project-setup
-      - release2pypi?:
+      - release?:
           type: approval
           requires:
             - build_and_test
-            - release2testpypi
           filters:
             branches:
-              only: circleci-project-setup
+              only: circleci-project-setup # moet zijn main (of master), maar voor testen ff zo
+      - release2testpypi:
+          requires:
+            - build_and_test
+            - release?
+          filters:
+            branches:
+              only: circleci-project-setup # moet zijn main (master?), maar voor testen ff zo
+
       - release2pypi:
           requires:
             - build_and_test
+            - release?
             - release2testpypi
-            - release2pypi?
           filters:
             branches:
               only: circleci-project-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,52 @@ jobs:
       - run: pre-commit install
       - run: tox
       - run: pre-commit run --all-files
+        # Iets met sonar voor PR:
+        # "sonar-scanner -Dsonar.github.oauth=${env.GITHUB_TOKEN} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.pullrequest.key=${env.CHANGE_ID} -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=molgenis/molgenis-py-bbmri-eric"
+        # voor main:
+        # "sonar-scanner"
+
+#  release:
+#    executor: my-executor
+#    steps:
+#      - checkout # checkout source code to working directory
+#      - run:
+#          command: | # create whl, install twine and publish to Test PyPI
+#            python3 setup.py sdist bdist_wheel
+#            sudo add-apt-repository universe -y
+#            sudo apt-get update
+#            sudo apt install -y python3-pip
+#            sudo pip install pipenv
+#            pipenv install twine
+#            pipenv run twine upload --repository testpypi dist/*
+#  pypi_publish:
+#    docker:
+#      - image: cimg/python:3.11.0
+#    steps:
+#      - checkout # checkout source code to working directory
+#      - run:
+#          command: | # create whl, install twine and publish to PyPI
+#            python3 setup.py sdist bdist_wheel
+#            sudo add-apt-repository universe -y
+#            sudo apt-get update
+#            sudo apt install -y python3-pip
+#            sudo pip install pipenv
+#            pipenv install twine
+#            pipenv run twine upload dist/*
+
+
 
 workflows:
   test-python-jobs:
     jobs:
       - build_and_test
+      - hold:
+          type: approval
+          requires:
+            - build_and_test
+#      - release:
+#          requires:
+#            - build_and_test # only deploy if the build_and_test job has completed
+#          filters:
+#            branches:
+#              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - checkout
       - run: pip install tox
-      - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/${REPOSITORY}.git
+      - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/molgenis/molgenis-py-bbmri-eric.git
       - run: git checkout -f main
       - run: git fetch --tags
       # bump the version based on the last tag and create a new tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,32 +9,17 @@ executors:
     working_directory: ~/repo
 
 jobs:
-  prepare:
+  build_and_test
     executor: my-executor    
     steps:
       - checkout
       - run: pip install tox
       - run: pip install pre-commit
       - run: pre-commit install
-      - persist_to_workspace:
-          # Must be an absolute path, or relative path from working_directory. This is a directory in the execution
-          # environment which is taken to be the root directory of the workspace.
-          root: ~/repo
-          # Must be relative path from root
-          paths:
-          - .
-  build:
-    executor: my-executor 
-    steps:
-      - attach_workspace:
-          # Must be absolute path or relative path from working_directory
-          at: ~/repo
-      - run: pip install tox
       - run: tox
       - run: pre-commit run --all-files
 
 workflows:
   test-python-jobs:
     jobs:
-      - prepare
-      - build
+      - build_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,15 +72,19 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-    #  - run: mkdir -p workspace
+          # Voor testen even --skip-existing toegevoegd
+          # push the new tag to molgenis/molgenis-py-bbmri-eric
+      - run:
+          name: Update tags
+          command: |
+            git config user.email "d.t.roelofs-prins@umcg.nl"
+            git config user.name "dtroelofsprins"
+            git push --tags origin main
       - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: ~/repo
           paths:
             -  .
-          # Voor testen even --skip-existing toegevoegd
-          # push the new tag to molgenis/molgenis-py-bbmri-eric
-      - run: git push --tags origin main
   release2pypi:
     executor: my-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,11 @@ jobs:
             NEW_PACKAGE_VERSION=$(bash bump-version.sh)
             echo $NEW_PACKAGE_VERSION
       - run: git checkout .
+      - run: RELEASE_SCOPE = patch
       - run: # build and publish the release
           command: |
             tox -e build
-            tox -e publish -- --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}"
+            tox -e publish -- --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
 
           # push the new tag to molgenis/molgenis-py-bbmri-eric
       # - run: git push --tags origin main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,13 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-      - run: cp $BASH_ENV bash.env
+      - run: mkdir -p workspace
+      - run: cp $BASH_ENV workspace/bash.env
       - persist_to_workspace:
-          root: .
+          root: ~/repo
           paths:
-            -  bash.env
+            -  .
+            -  ~/repo/workspace/bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet
@@ -88,12 +90,13 @@ jobs:
       - checkout
       - run: pip install tox
       - attach_workspace:
-          at: .
+          at: ~/repo
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
-      - run: cat bash.env >> $BASH_ENV
+      - run: cat workspace/bash.env >> $BASH_ENV
       - run:
           command: |
+            echo $NEW_PACKAGE_VERSION
             TEST=$NEW_PACKAGE_VERSION
             echo $TEST
       - run: echo in release new version is $NEW_PACKAGE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,11 +98,7 @@ workflows:
     jobs:
       - run_tests
   release:
-    when:
-      or:
-        - equal: [ patch, <<pipeline.parameters.release_scope>> ]
-        - equal: [ minor, <<pipeline.parameters.release_scope>> ]
-        - equal: [ major, <<pipeline.parameters.release_scope>> ]
+    when: << pipeline.parameters.release >>
     jobs:
     - release2testpypi:
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
           root: .
           paths:
             - .
+            - bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
           # Maar voor testen even nog niet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ workflows:
           requires:
             - build_and_test
             - release2testpypi
+            - release2pypi?
           filters:
             branches:
               only: circleci-project-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,48 +23,66 @@ jobs:
         # voor main:
         # "sonar-scanner"
 
-#  release:
-#    executor: my-executor
-#    steps:
-#      - checkout # checkout source code to working directory
-#      - run:
-#          command: | # create whl, install twine and publish to Test PyPI
-#            python3 setup.py sdist bdist_wheel
-#            sudo add-apt-repository universe -y
-#            sudo apt-get update
-#            sudo apt install -y python3-pip
-#            sudo pip install pipenv
-#            pipenv install twine
-#            pipenv run twine upload --repository testpypi dist/*
-#  pypi_publish:
-#    docker:
-#      - image: cimg/python:3.11.0
-#    steps:
-#      - checkout # checkout source code to working directory
-#      - run:
-#          command: | # create whl, install twine and publish to PyPI
-#            python3 setup.py sdist bdist_wheel
-#            sudo add-apt-repository universe -y
-#            sudo apt-get update
-#            sudo apt install -y python3-pip
-#            sudo pip install pipenv
-#            pipenv install twine
-#            pipenv run twine upload dist/*
+  release2testpypi:
+    executor: my-executor
+    steps:
+      - checkout
+      - run: pip install tox
+      - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/${REPOSITORY}.git
+      - run: git checkout -f main
+      - run: git fetch --tags
+      # bump the version based on the last tag and create a new tag
+      - run:
+          command: |
+            pip install bumpversion
+            NEW_PACKAGE_VERSION=$(bash bump-version.sh)
+            echo $NEW_PACKAGE_VERSION
+      - run: git checkout .
+      - run: # build and publish the release
+          command: |
+            tox -e build
+            tox -e publish -- --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}"
 
+          # push the new tag to molgenis/molgenis-py-bbmri-eric
+      # - run: git push --tags origin main
+  release2pypi:
+    executor: my-executor
+    steps:
+      - checkout
+      - run: pip install tox
+      # do the actual release to PyPi
+      # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
+      - run:
+          name: message slack about release and updated demo server
+          command: |
+            curl -d "token=${SLACK_TOKEN}" \
+            -d "text=molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
+            -d "channel=C01TN8FU480" \
+            -X POST https://slack.com/api/chat.postMessage
 
 
 workflows:
-  test-python-jobs:
+  build_pr_or_release:
     jobs:
       - build_and_test
-      - release2testpypi?:
-          description: Release to testpypi?
+      - release2testpypi:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only: circleci-project-setup
+      - release2pypi?:
           type: approval
           requires:
             - build_and_test
-#      - release:
-#          requires:
-#            - build_and_test # only deploy if the build_and_test job has completed
-#          filters:
-#            branches:
-#              only: main
+            - release2testpypi
+          filters:
+            branches:
+              only: circleci-project-setup
+      - release2pypi:
+          requires:
+            - build_and_test
+            - release2testpypi
+          filters:
+            branches:
+              only: circleci-project-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,10 @@ jobs:
           command: |
             tox -e build
             tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-      - run: cp $"BASH_ENV" bash.env
+      - run: cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: .
           paths:
-            - .
             - bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,16 +19,16 @@ jobs:
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory in the execution
           # environment which is taken to be the root directory of the workspace.
-          root: ~/repo/workspace
+          root: ~/repo
           # Must be relative path from root
           paths:
-          - output
+          - .
   build:
     executor: my-executor 
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
-          at: ~/repo/workspace
+          at: ~/repo
       - run: tox
       - run: pre-commit run --all-files
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       # do the actual release to PyPi
       # Maar gaat waarschijnlijk niet goed omdat het een andere env is. Iets met workspace doen?
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
-      - run: tox -e publish -- --repository testpypi --skip-existing --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_PASSWORD}
+      - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
       - run:
           name: message slack about the release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ version: 2.1
 parameters:
   release:
     type: boolean
-    default: true
+    default: false
   release_scope:
     type: string
-    default: patch
+    default: chore
 
 executors:
   my-executor:
@@ -78,11 +78,9 @@ jobs:
           root: ~/repo
           paths:
             -  .
-          #  -  workspace/bash.env
           # Voor testen even --skip-existing toegevoegd
           # push the new tag to molgenis/molgenis-py-bbmri-eric
-          # Maar voor testen even nog niet
-      # - run: git push --tags origin main
+      - run: git push --tags origin main
   release2pypi:
     executor: my-executor
     steps:
@@ -93,15 +91,14 @@ jobs:
       # do the actual release to PyPi
       # - run: tox -e publish -- --repository pypi --username ${PYPI_USERNAME} --password ${PYPI_TOKEN}
       - run: cat bash.env >> $BASH_ENV
-      - run: echo $NEW_PACKAGE_VERSION
       - run: tox -e publish -- --skip-existing --repository testpypi --username ${TESTPYPI_USERNAME} --password ${TESTPYPI_TOKEN}
-  #    - run:
-  #        name: message slack about the release
-  #        command: |
-  #          curl -d "token=${SLACK_TOKEN}" \
-  ##          -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
-   #         -d "channel=C01TN8FU480" \
-   #         -X POST https://slack.com/api/chat.postMessage
+      - run:
+          name: Message slack about the release
+          command: |
+            curl -d "token=${SLACK_TOKEN}" \
+            -d "text=TEST-TEST-TEST-molgenis-py-bbmri-eric ${NEW_PACKAGE_VERSION} is released. Check it out: https://pypi.org/project/molgenis-py-bbmri-eric/" \
+            -d "channel=C013UDLKFEW" \
+            -X POST https://slack.com/api/chat.postMessage
 
 workflows:
   build_and_test:

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ changedir = {toxinidir}
 deps = twine
 commands =
     python -m twine check dist/*
-    python -m twine upload --skip-existing {posargs:--repository testpypi} dist/*
+    python -m twine upload {posargs:--repository testpypi} dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ changedir = {toxinidir}
 deps = twine
 commands =
     python -m twine check dist/*
-    python -m twine upload {posargs:--repository testpypi} dist/*
+    python -m twine upload --skip-existing {posargs:--repository testpypi} dist/*


### PR DESCRIPTION
I've tested all steps including the release part (by changing the filter branch in the release workflow to circleci-project-setup instead of main) all worked fine, only thing that failed is the `git push tags origin main`, I hope this is due to the fact that branch was not main.


#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] Updated CHANGELOG.md
